### PR TITLE
Improvements to modulation control and V/Oct calibration

### DIFF
--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2860,12 +2860,6 @@
 		)
 	)
 	(junction
-		(at 118.11 107.95)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "03db208d-5d19-4e11-941b-07212ebd1629")
-	)
-	(junction
 		(at 67.31 110.49)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2884,16 +2878,10 @@
 		(uuid "104cf8d2-0ad0-4638-9e97-12510bca5ef0")
 	)
 	(junction
-		(at 118.11 132.08)
+		(at 130.81 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "2a2975ae-7e64-478b-8539-55c789703f6b")
-	)
-	(junction
-		(at 127 100.33)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "31b42941-bebf-4fe9-aaf8-999b2c833ddc")
+		(uuid "23d18312-e5fd-4043-94fe-4ae1dafac028")
 	)
 	(junction
 		(at 137.16 100.33)
@@ -3155,6 +3143,16 @@
 	)
 	(wire
 		(pts
+			(xy 123.19 109.22) (xy 123.19 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1df88b2f-fbb8-4936-8fd8-111afad70543")
+	)
+	(wire
+		(pts
 			(xy 203.2 20.32) (xy 203.2 24.13)
 		)
 		(stroke
@@ -3242,16 +3240,6 @@
 			(type default)
 		)
 		(uuid "2fa9d208-97af-4c94-b741-c8f286984c08")
-	)
-	(wire
-		(pts
-			(xy 127 100.33) (xy 137.16 100.33)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "32053142-6834-4d37-8dbe-90155cc46916")
 	)
 	(wire
 		(pts
@@ -3585,16 +3573,6 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 132.08) (xy 118.11 134.62)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "73d70821-c7ef-43fd-96ef-7ba7d9a49a0e")
-	)
-	(wire
-		(pts
 			(xy 97.79 107.95) (xy 100.33 107.95)
 		)
 		(stroke
@@ -3635,7 +3613,7 @@
 	)
 	(wire
 		(pts
-			(xy 127 100.33) (xy 127 102.87)
+			(xy 130.81 100.33) (xy 130.81 104.14)
 		)
 		(stroke
 			(width 0)
@@ -3715,6 +3693,16 @@
 	)
 	(wire
 		(pts
+			(xy 118.11 130.81) (xy 118.11 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8511b0d9-93c0-4021-bfb5-22517beaa5c9")
+	)
+	(wire
+		(pts
 			(xy 236.22 64.77) (xy 240.03 64.77)
 		)
 		(stroke
@@ -3772,6 +3760,16 @@
 			(type default)
 		)
 		(uuid "96ccb288-08a0-4211-9d1c-04453028ecd5")
+	)
+	(wire
+		(pts
+			(xy 130.81 100.33) (xy 137.16 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9766a8bf-d9a9-427e-9206-92e0ad0dd9c3")
 	)
 	(wire
 		(pts
@@ -3842,16 +3840,6 @@
 			(type default)
 		)
 		(uuid "9ce73ca3-f476-450f-be98-841a6b45f449")
-	)
-	(wire
-		(pts
-			(xy 118.11 107.95) (xy 119.38 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "9d77140e-ee74-47c0-a380-5a62a0a178f9")
 	)
 	(wire
 		(pts
@@ -3932,6 +3920,26 @@
 			(type default)
 		)
 		(uuid "ab263ed0-502d-4085-b127-aa1b42b5a221")
+	)
+	(wire
+		(pts
+			(xy 130.81 100.33) (xy 127 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abd6b85c-c93c-407f-8006-7d692c731ed6")
+	)
+	(wire
+		(pts
+			(xy 118.11 140.97) (xy 118.11 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ac68a671-7262-4ede-981e-35a8671b1567")
 	)
 	(wire
 		(pts
@@ -4045,6 +4053,16 @@
 	)
 	(wire
 		(pts
+			(xy 123.19 127) (xy 121.92 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b9a250bc-63b4-4abe-9f90-8afce1fdad66")
+	)
+	(wire
+		(pts
 			(xy 267.97 67.31) (xy 271.78 67.31)
 		)
 		(stroke
@@ -4115,16 +4133,6 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 107.95) (xy 118.11 105.41)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "cd8938b6-21f4-47a7-9619-5f5eb208a997")
-	)
-	(wire
-		(pts
 			(xy 144.78 113.03) (xy 144.78 115.57)
 		)
 		(stroke
@@ -4185,6 +4193,16 @@
 	)
 	(wire
 		(pts
+			(xy 118.11 105.41) (xy 118.11 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dcdc983e-d335-4032-9a74-548d379573e1")
+	)
+	(wire
+		(pts
 			(xy 34.29 73.66) (xy 36.83 73.66)
 		)
 		(stroke
@@ -4212,16 +4230,6 @@
 			(type default)
 		)
 		(uuid "dfd10b9a-4246-4eef-beee-81fb3f43496b")
-	)
-	(wire
-		(pts
-			(xy 118.11 118.11) (xy 118.11 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e0a524e7-585d-492b-ac14-fdf0f9e607e4")
 	)
 	(wire
 		(pts
@@ -4275,23 +4283,13 @@
 	)
 	(wire
 		(pts
-			(xy 127 113.03) (xy 127 115.57)
+			(xy 130.81 114.3) (xy 130.81 115.57)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "e5e6fe3e-939d-4f42-b041-daa36d907c32")
-	)
-	(wire
-		(pts
-			(xy 118.11 130.81) (xy 118.11 132.08)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e6e1e978-0793-4d4e-ad7f-709f62dfa7f3")
 	)
 	(wire
 		(pts
@@ -4345,16 +4343,6 @@
 	)
 	(wire
 		(pts
-			(xy 114.3 127) (xy 114.3 132.08)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f44ef6ab-f740-4828-b9b9-c88bc0a32c1b")
-	)
-	(wire
-		(pts
 			(xy 171.45 71.12) (xy 173.99 71.12)
 		)
 		(stroke
@@ -4362,16 +4350,6 @@
 			(type default)
 		)
 		(uuid "f9ca19f0-92fd-4d1a-9d8c-3859b952a4d8")
-	)
-	(wire
-		(pts
-			(xy 114.3 132.08) (xy 118.11 132.08)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "fbcfcb1c-d71e-4e82-a8d0-ec8a4e2fd66b")
 	)
 	(wire
 		(pts
@@ -4913,7 +4891,7 @@
 	)
 	(symbol
 		(lib_id "power:-12V")
-		(at 127 115.57 180)
+		(at 130.81 115.57 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4921,7 +4899,7 @@
 		(dnp no)
 		(uuid "1566cf2a-5fd2-49eb-98d6-b14774fd127a")
 		(property "Reference" "#PWR021"
-			(at 127 111.76 0)
+			(at 130.81 111.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4930,7 +4908,7 @@
 			)
 		)
 		(property "Value" "-12V"
-			(at 127 120.65 0)
+			(at 130.81 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4938,7 +4916,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 127 115.57 0)
+			(at 130.81 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4947,7 +4925,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 127 115.57 0)
+			(at 130.81 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4956,7 +4934,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 127 115.57 0)
+			(at 130.81 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5778,7 +5756,7 @@
 	)
 	(symbol
 		(lib_id "Transistor_BJT:BC558")
-		(at 124.46 107.95 0)
+		(at 128.27 109.22 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -5787,7 +5765,7 @@
 		(dnp no)
 		(uuid "3e8ff1da-4dfe-4f92-b3e8-74f7ebcf7740")
 		(property "Reference" "Q1"
-			(at 129.54 106.6799 0)
+			(at 133.35 107.9499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5796,7 +5774,7 @@
 			)
 		)
 		(property "Value" "BC558"
-			(at 129.54 109.2199 0)
+			(at 133.35 110.4899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5805,7 +5783,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_THT:TO-92_Inline"
-			(at 129.54 106.045 0)
+			(at 133.35 107.315 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5816,7 +5794,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf"
-			(at 124.46 107.95 0)
+			(at 128.27 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5826,7 +5804,7 @@
 			)
 		)
 		(property "Description" "0.1A Ic, 30V Vce, PNP Small Signal Transistor, TO-92"
-			(at 124.46 107.95 0)
+			(at 128.27 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6274,7 +6252,7 @@
 				)
 			)
 		)
-		(property "Value" "100k"
+		(property "Value" "1k5"
 			(at 111.76 114.3 90)
 			(effects
 				(font
@@ -6671,7 +6649,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_Trim_US")
-		(at 118.11 127 180)
+		(at 118.11 127 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6679,7 +6657,7 @@
 		(dnp no)
 		(uuid "6d52a498-9f38-4108-b7ea-3c5d9215c1c6")
 		(property "Reference" "RV5"
-			(at 120.65 128.2701 0)
+			(at 115.57 125.7299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6688,7 +6666,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 120.65 125.7301 0)
+			(at 115.57 128.2699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6715,7 +6693,7 @@
 			)
 		)
 		(property "Description" "V/Oct Calibration"
-			(at 112.014 136.144 90)
+			(at 109.728 132.08 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6962,7 +6940,7 @@
 				)
 			)
 		)
-		(property "Value" "1k5"
+		(property "Value" "100k"
 			(at 77.47 120.65 90)
 			(effects
 				(font
@@ -7954,46 +7932,46 @@
 			)
 		)
 		(pin "3"
-			(uuid "df13b966-ae31-47c3-84b2-0192cca2d2c2")
+			(uuid "df13b966-ae31-47c3-84b2-0192cca2d2c3")
 		)
 		(pin "2"
-			(uuid "314bb5ce-15c3-4d11-92ae-04e721f9033f")
+			(uuid "314bb5ce-15c3-4d11-92ae-04e721f90340")
 		)
 		(pin "4"
-			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37b")
+			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37d")
 		)
 		(pin "7"
 			(uuid "77aaaf80-8f55-436f-b536-c603e6b43705")
 		)
 		(pin "11"
-			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff5")
+			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff7")
 		)
 		(pin "8"
-			(uuid "66103d65-2374-465b-8e61-597635a275cf")
+			(uuid "66103d65-2374-465b-8e61-597635a275d1")
 		)
 		(pin "6"
 			(uuid "73f1a8dd-9d7f-490d-8380-c9a3d42b8cfb")
 		)
 		(pin "1"
-			(uuid "f8ef71cb-37ff-45b6-b2c4-6af18dafbed7")
+			(uuid "f8ef71cb-37ff-45b6-b2c4-6af18dafbed8")
 		)
 		(pin "13"
-			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe248e")
+			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe2490")
 		)
 		(pin "14"
-			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e715")
+			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e717")
 		)
 		(pin "12"
-			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384b")
+			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384d")
 		)
 		(pin "5"
 			(uuid "0bc6cf02-6f70-4bd8-88b0-42de3beea569")
 		)
 		(pin "9"
-			(uuid "9acbb5a0-ddaf-4b25-b24c-b4b97eaea58b")
+			(uuid "9acbb5a0-ddaf-4b25-b24c-b4b97eaea58d")
 		)
 		(pin "10"
-			(uuid "4bd68a0a-02bc-4965-bd23-a853b692ceaf")
+			(uuid "4bd68a0a-02bc-4965-bd23-a853b692ceb1")
 		)
 		(instances
 			(project "DMH_VCO_40106_PCB"
@@ -8267,40 +8245,40 @@
 			(uuid "2697b587-35f1-4109-877d-4239f8815290")
 		)
 		(pin "4"
-			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37c")
+			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37e")
 		)
 		(pin "7"
-			(uuid "be82eefa-46b8-485c-8cde-feb0b3e93a71")
+			(uuid "be82eefa-46b8-485c-8cde-feb0b3e93a72")
 		)
 		(pin "11"
-			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff6")
+			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff8")
 		)
 		(pin "8"
-			(uuid "66103d65-2374-465b-8e61-597635a275d0")
+			(uuid "66103d65-2374-465b-8e61-597635a275d2")
 		)
 		(pin "6"
-			(uuid "3811c3bc-ffea-437c-ae0e-5cbed1ee3951")
+			(uuid "3811c3bc-ffea-437c-ae0e-5cbed1ee3952")
 		)
 		(pin "1"
 			(uuid "ac264e28-6087-419b-9bde-26a7186a8976")
 		)
 		(pin "13"
-			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe248f")
+			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe2491")
 		)
 		(pin "14"
-			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e716")
+			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e718")
 		)
 		(pin "12"
-			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384c")
+			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384e")
 		)
 		(pin "5"
-			(uuid "933b4c9c-0993-4992-a6a1-02a42d74cd1a")
+			(uuid "933b4c9c-0993-4992-a6a1-02a42d74cd1b")
 		)
 		(pin "9"
-			(uuid "9acbb5a0-ddaf-4b25-b24c-b4b97eaea58c")
+			(uuid "9acbb5a0-ddaf-4b25-b24c-b4b97eaea58e")
 		)
 		(pin "10"
-			(uuid "4bd68a0a-02bc-4965-bd23-a853b692ceb0")
+			(uuid "4bd68a0a-02bc-4965-bd23-a853b692ceb2")
 		)
 		(instances
 			(project "DMH_VCO_40106_PCB"
@@ -8514,6 +8492,76 @@
 			(project "VCO mki PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "RV4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
+		(at 118.11 137.16 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ca5f716e-0e59-472d-b5e5-6e6461509e5c")
+		(property "Reference" "R38"
+			(at 120.65 135.8899 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "470R"
+			(at 120.65 138.4299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 119.126 137.414 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 118.11 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 118.11 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "df926b64-12dd-46d8-83ef-f083b7cde654")
+		)
+		(pin "1"
+			(uuid "eeb98fed-4c16-45dd-acd3-814e7d34c661")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R38")
 					(unit 1)
 				)
 			)
@@ -8759,34 +8807,34 @@
 			(uuid "314bb5ce-15c3-4d11-92ae-04e721f90341")
 		)
 		(pin "4"
-			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37d")
+			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37f")
 		)
 		(pin "7"
-			(uuid "be82eefa-46b8-485c-8cde-feb0b3e93a72")
+			(uuid "be82eefa-46b8-485c-8cde-feb0b3e93a73")
 		)
 		(pin "11"
-			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff7")
+			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff9")
 		)
 		(pin "8"
 			(uuid "c4a677a5-ae66-4e24-9acf-702dde2d2ebf")
 		)
 		(pin "6"
-			(uuid "3811c3bc-ffea-437c-ae0e-5cbed1ee3952")
+			(uuid "3811c3bc-ffea-437c-ae0e-5cbed1ee3953")
 		)
 		(pin "1"
 			(uuid "f8ef71cb-37ff-45b6-b2c4-6af18dafbed9")
 		)
 		(pin "13"
-			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe2490")
+			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe2492")
 		)
 		(pin "14"
-			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e717")
+			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e719")
 		)
 		(pin "12"
-			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384d")
+			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384f")
 		)
 		(pin "5"
-			(uuid "933b4c9c-0993-4992-a6a1-02a42d74cd1b")
+			(uuid "933b4c9c-0993-4992-a6a1-02a42d74cd1c")
 		)
 		(pin "9"
 			(uuid "ecc8e278-39ef-4f68-927a-beeb75a2945b")
@@ -9075,7 +9123,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 118.11 134.62 0)
+		(at 118.11 143.51 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9084,7 +9132,7 @@
 		(fields_autoplaced yes)
 		(uuid "d9dee118-bd8d-46d6-a570-70104a0b3ff0")
 		(property "Reference" "#PWR019"
-			(at 118.11 140.97 0)
+			(at 118.11 149.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9093,7 +9141,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 118.11 139.7 0)
+			(at 118.11 148.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9101,7 +9149,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 118.11 134.62 0)
+			(at 118.11 143.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9110,7 +9158,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 118.11 134.62 0)
+			(at 118.11 143.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9119,7 +9167,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 118.11 134.62 0)
+			(at 118.11 143.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -4458,16 +4458,6 @@
 		)
 		(uuid "a21d1940-3de9-4795-a44e-603b4169a4e7")
 	)
-	(text "used 2 68k in parallel for now"
-		(exclude_from_sim no)
-		(at 34.29 51.562 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-		)
-		(uuid "fa3ae6a7-9876-491c-b8f9-58b3c9484965")
-	)
 	(hierarchical_label "Exp FM In 1"
 		(shape input)
 		(at 25.4 127 180)
@@ -6252,7 +6242,7 @@
 				)
 			)
 		)
-		(property "Value" "1k5"
+		(property "Value" "3k3"
 			(at 111.76 114.3 90)
 			(effects
 				(font
@@ -7553,7 +7543,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "2.2nF"
+		(property "Value" "10nF"
 			(at 161.29 110.4899 0)
 			(effects
 				(font
@@ -8516,7 +8506,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "470R"
+		(property "Value" "510R"
 			(at 120.65 138.4299 0)
 			(effects
 				(font

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2884,6 +2884,12 @@
 		(uuid "23d18312-e5fd-4043-94fe-4ae1dafac028")
 	)
 	(junction
+		(at 41.91 73.66)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2f088860-0d76-4f91-95f8-6a88de66696d")
+	)
+	(junction
 		(at 137.16 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2980,6 +2986,12 @@
 		(uuid "cd45eacf-dd4b-447d-915a-ff112a50087e")
 	)
 	(junction
+		(at 26.67 78.74)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d05b33e3-2cd2-478b-8ba6-989f7a417815")
+	)
+	(junction
 		(at 199.39 67.31)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -3000,6 +3012,16 @@
 			(type default)
 		)
 		(uuid "00a0a9e5-dea8-4c5e-91e1-16b71669322d")
+	)
+	(wire
+		(pts
+			(xy 46.99 77.47) (xy 41.91 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "02b5da5f-cecd-4f87-8932-ff756249eff3")
 	)
 	(wire
 		(pts
@@ -3030,6 +3052,16 @@
 			(type default)
 		)
 		(uuid "0804a9e7-ad2e-496b-9eb1-27ea37144d52")
+	)
+	(wire
+		(pts
+			(xy 41.91 73.66) (xy 43.18 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "081cea57-d0c1-46d6-a3ad-e352dcb2e082")
 	)
 	(wire
 		(pts
@@ -3253,6 +3285,16 @@
 	)
 	(wire
 		(pts
+			(xy 30.48 83.82) (xy 30.48 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "33057753-0412-4ec2-abfb-77f31ce66ed7")
+	)
+	(wire
+		(pts
 			(xy 173.99 77.47) (xy 173.99 71.12)
 		)
 		(stroke
@@ -3343,6 +3385,16 @@
 	)
 	(wire
 		(pts
+			(xy 26.67 78.74) (xy 26.67 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e124dc0-dcbe-4427-b544-14de8f108428")
+	)
+	(wire
+		(pts
 			(xy 25.4 39.37) (xy 25.4 46.99)
 		)
 		(stroke
@@ -3370,16 +3422,6 @@
 			(type default)
 		)
 		(uuid "3fb06f23-d65f-4728-a42c-c276aa1b5e35")
-	)
-	(wire
-		(pts
-			(xy 44.45 73.66) (xy 46.99 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "41ae5fb1-ff52-4683-991b-ad8649c57c8e")
 	)
 	(wire
 		(pts
@@ -3553,7 +3595,7 @@
 	)
 	(wire
 		(pts
-			(xy 19.05 64.77) (xy 19.05 67.31)
+			(xy 15.24 64.77) (xy 15.24 67.31)
 		)
 		(stroke
 			(width 0)
@@ -3580,6 +3622,16 @@
 			(type default)
 		)
 		(uuid "7484ce42-8e99-441f-9561-d2dfe2b69f53")
+	)
+	(wire
+		(pts
+			(xy 30.48 73.66) (xy 33.02 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7552adeb-7d9f-4963-b611-e25f39e46b8e")
 	)
 	(wire
 		(pts
@@ -3623,7 +3675,7 @@
 	)
 	(wire
 		(pts
-			(xy 54.61 73.66) (xy 63.5 73.66)
+			(xy 60.96 73.66) (xy 63.5 73.66)
 		)
 		(stroke
 			(width 0)
@@ -3753,6 +3805,16 @@
 	)
 	(wire
 		(pts
+			(xy 40.64 73.66) (xy 41.91 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "95246720-10ba-4e4e-aea5-1636c6584648")
+	)
+	(wire
+		(pts
 			(xy 100.33 118.11) (xy 100.33 107.95)
 		)
 		(stroke
@@ -3853,6 +3915,16 @@
 	)
 	(wire
 		(pts
+			(xy 26.67 78.74) (xy 30.48 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9e9687b5-780d-4d31-96c0-752649d60429")
+	)
+	(wire
+		(pts
 			(xy 170.18 53.34) (xy 170.18 57.15)
 		)
 		(stroke
@@ -3873,7 +3945,7 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 64.77) (xy 30.48 69.85)
+			(xy 26.67 64.77) (xy 26.67 69.85)
 		)
 		(stroke
 			(width 0)
@@ -3903,7 +3975,7 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 64.77) (xy 19.05 64.77)
+			(xy 26.67 64.77) (xy 15.24 64.77)
 		)
 		(stroke
 			(width 0)
@@ -3963,6 +4035,16 @@
 	)
 	(wire
 		(pts
+			(xy 50.8 73.66) (xy 53.34 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "adf41306-b614-4256-8223-63f28cc7b268")
+	)
+	(wire
+		(pts
 			(xy 152.4 86.36) (xy 157.48 86.36)
 		)
 		(stroke
@@ -3990,6 +4072,16 @@
 			(type default)
 		)
 		(uuid "b09cb931-8575-423f-9251-3f6344a7d602")
+	)
+	(wire
+		(pts
+			(xy 41.91 77.47) (xy 41.91 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b0eabf79-a108-4076-8c06-16e7a07c776d")
 	)
 	(wire
 		(pts
@@ -4153,7 +4245,7 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 87.63) (xy 30.48 90.17)
+			(xy 26.67 87.63) (xy 26.67 90.17)
 		)
 		(stroke
 			(width 0)
@@ -4200,16 +4292,6 @@
 			(type default)
 		)
 		(uuid "dcdc983e-d335-4032-9a74-548d379573e1")
-	)
-	(wire
-		(pts
-			(xy 34.29 73.66) (xy 36.83 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "dce57fcf-e218-44f7-9824-26f67de74ffe")
 	)
 	(wire
 		(pts
@@ -4313,7 +4395,7 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 77.47) (xy 30.48 80.01)
+			(xy 26.67 77.47) (xy 26.67 78.74)
 		)
 		(stroke
 			(width 0)
@@ -4543,17 +4625,16 @@
 		(uuid "f292de43-822b-4f07-8dce-619c8b3837d0")
 	)
 	(symbol
-		(lib_id "Device:R_US")
-		(at 40.64 73.66 90)
+		(lib_id "Device:R_Potentiometer_Trim_US")
+		(at 46.99 73.66 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "01e8a046-fa9f-4d17-9a61-8e7d9ee2f54d")
 		(property "Reference" "R5"
-			(at 40.64 67.31 90)
+			(at 48.26 68.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4561,7 +4642,7 @@
 			)
 		)
 		(property "Value" "1M"
-			(at 40.64 69.85 90)
+			(at 45.72 68.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4569,7 +4650,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 40.894 72.644 90)
+			(at 46.99 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4578,7 +4659,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 40.64 73.66 0)
+			(at 46.99 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4586,8 +4667,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Resistor, US symbol"
-			(at 40.64 73.66 0)
+		(property "Description" "Trim-potentiometer, US symbol"
+			(at 46.99 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4600,6 +4681,9 @@
 		)
 		(pin "1"
 			(uuid "5d8869d8-6774-4698-b475-c825d65c74d1")
+		)
+		(pin "3"
+			(uuid "c9348fca-780c-4fdf-8937-4b7fbe22c419")
 		)
 		(instances
 			(project "VCO mki PCB"
@@ -5673,6 +5757,74 @@
 			(project "VCO mki PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "U2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
+		(at 36.83 73.66 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "37d7652a-b7d0-40b9-848a-d1215cde57fa")
+		(property "Reference" "R39"
+			(at 36.83 67.31 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "500k"
+			(at 36.83 69.85 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 37.084 72.644 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 36.83 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 36.83 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "889af033-86e0-4d55-887e-0deebd8fe7a1")
+		)
+		(pin "1"
+			(uuid "5fcddf7e-5979-458f-b16a-218f989eaed1")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R39")
 					(unit 1)
 				)
 			)
@@ -6982,7 +7134,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 19.05 67.31 0)
+		(at 15.24 67.31 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6991,7 +7143,7 @@
 		(fields_autoplaced yes)
 		(uuid "794bd708-effe-4ce9-a56d-c70efa2ab1b4")
 		(property "Reference" "#PWR03"
-			(at 19.05 73.66 0)
+			(at 15.24 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7000,7 +7152,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 19.05 72.39 0)
+			(at 15.24 72.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7008,7 +7160,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 19.05 67.31 0)
+			(at 15.24 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7017,7 +7169,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 19.05 67.31 0)
+			(at 15.24 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7026,7 +7178,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 19.05 67.31 0)
+			(at 15.24 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7455,7 +7607,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 30.48 73.66 0)
+		(at 26.67 73.66 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7463,7 +7615,7 @@
 		(dnp no)
 		(uuid "95116ff5-e8ba-485c-9056-08caa02a2fef")
 		(property "Reference" "RV2"
-			(at 27.94 72.3899 0)
+			(at 24.13 72.3899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7472,7 +7624,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 27.94 74.9299 0)
+			(at 24.13 74.9299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7481,7 +7633,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 30.48 73.66 0)
+			(at 26.67 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7490,7 +7642,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 30.48 73.66 0)
+			(at 26.67 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7499,7 +7651,7 @@
 			)
 		)
 		(property "Description" "Fine"
-			(at 25.654 69.85 0)
+			(at 21.844 69.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7973,8 +8125,8 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R_US")
-		(at 30.48 83.82 0)
+		(lib_id "Device:R_Potentiometer_Trim_US")
+		(at 26.67 83.82 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7983,25 +8135,25 @@
 		(fields_autoplaced yes)
 		(uuid "aad5f486-f28b-4bf3-a898-786ee2e7c8fb")
 		(property "Reference" "R3"
-			(at 33.02 82.5499 0)
+			(at 24.13 82.5499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
+				(justify right)
 			)
 		)
 		(property "Value" "100k"
-			(at 33.02 85.0899 0)
+			(at 24.13 85.0899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
+				(justify right)
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 31.496 84.074 90)
+			(at 26.67 83.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8010,7 +8162,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 30.48 83.82 0)
+			(at 26.67 83.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8018,8 +8170,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Resistor, US symbol"
-			(at 30.48 83.82 0)
+		(property "Description" "Trim-potentiometer, US symbol"
+			(at 26.67 83.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8032,6 +8184,9 @@
 		)
 		(pin "1"
 			(uuid "97bda6a7-3c87-4137-bd93-95d19d46072b")
+		)
+		(pin "3"
+			(uuid "cb634b3f-df96-447a-9cb7-01bd091c5fe8")
 		)
 		(instances
 			(project "VCO mki PCB"
@@ -8843,7 +8998,7 @@
 	)
 	(symbol
 		(lib_id "power:-12V")
-		(at 30.48 90.17 180)
+		(at 26.67 90.17 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8852,7 +9007,7 @@
 		(fields_autoplaced yes)
 		(uuid "d5d05cb4-ab9e-407a-8bfe-9564a8296a03")
 		(property "Reference" "#PWR04"
-			(at 30.48 86.36 0)
+			(at 26.67 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8861,7 +9016,7 @@
 			)
 		)
 		(property "Value" "-12V"
-			(at 30.48 95.25 0)
+			(at 26.67 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8869,7 +9024,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 30.48 90.17 0)
+			(at 26.67 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8878,7 +9033,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 30.48 90.17 0)
+			(at 26.67 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8887,7 +9042,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 30.48 90.17 0)
+			(at 26.67 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9444,7 +9599,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 50.8 73.66 90)
+		(at 57.15 73.66 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9453,7 +9608,7 @@
 		(fields_autoplaced yes)
 		(uuid "e3501d8c-0ad3-4a53-9bfd-fdddf154685c")
 		(property "Reference" "TH2"
-			(at 50.8 67.31 90)
+			(at 57.15 67.31 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9461,7 +9616,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 50.8 69.85 90)
+			(at 57.15 69.85 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9469,7 +9624,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 50.8 73.66 0)
+			(at 57.15 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9478,7 +9633,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 73.66 0)
+			(at 57.15 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9487,7 +9642,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 50.8 73.66 0)
+			(at 57.15 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2860,61 +2860,91 @@
 		)
 	)
 	(junction
-		(at 166.37 24.13)
+		(at 118.11 107.95)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "03db208d-5d19-4e11-941b-07212ebd1629")
+	)
+	(junction
+		(at 67.31 110.49)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "08cc19aa-2d15-4bb6-9dbb-7656ab235d5b")
+	)
+	(junction
+		(at 193.04 24.13)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "08f16d58-ed15-4500-a51f-d34b0ae83f98")
 	)
 	(junction
-		(at 82.55 129.54)
+		(at 63.5 110.49)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "104cf8d2-0ad0-4638-9e97-12510bca5ef0")
+	)
+	(junction
+		(at 118.11 132.08)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "2a2975ae-7e64-478b-8539-55c789703f6b")
 	)
 	(junction
-		(at 100.33 100.33)
+		(at 127 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "31b42941-bebf-4fe9-aaf8-999b2c833ddc")
 	)
 	(junction
-		(at 110.49 100.33)
+		(at 137.16 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "31e0807b-f998-4f11-9032-ae7bd302d351")
 	)
 	(junction
-		(at 63.5 133.35)
+		(at 100.33 107.95)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "37bc4491-84b5-4a41-b382-e372e71c3905")
+		(uuid "35772588-b310-402d-95d1-bb62a12f9b7d")
 	)
 	(junction
-		(at 153.67 24.13)
+		(at 237.49 26.67)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3f4e7280-9597-4d6e-abf4-5697e7370793")
+	)
+	(junction
+		(at 63.5 107.95)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3fac9c83-7fa4-4206-9ef7-37fe4d3c474f")
+	)
+	(junction
+		(at 180.34 24.13)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "5118ec97-292c-4e63-b0c1-0807cda69d81")
 	)
 	(junction
-		(at 176.53 24.13)
+		(at 203.2 24.13)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "64b2a538-f8aa-40c9-b5a7-dd9c9c378593")
 	)
 	(junction
-		(at 130.81 86.36)
+		(at 157.48 86.36)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "71b63799-edab-47a1-8541-dbe29f759bd2")
 	)
 	(junction
-		(at 212.09 26.67)
+		(at 236.22 64.77)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "7bdc28c0-aa8d-4879-b9d9-fec06df6ed7e")
+		(uuid "814bf1cb-0f24-43e1-8347-dd59c37c0dfa")
 	)
 	(junction
-		(at 190.5 29.21)
+		(at 217.17 29.21)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "87560534-6723-4cfc-b5e1-e63f9ec9f5a5")
@@ -2926,56 +2956,66 @@
 		(uuid "999cab1d-6ec4-4bf1-818d-422424e7a463")
 	)
 	(junction
-		(at 82.55 107.95)
+		(at 87.63 107.95)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "9d48101d-f22b-4993-a506-962f1b0f2500")
+		(uuid "a4fd3de1-7483-40c8-a4a2-a59502200f06")
 	)
 	(junction
-		(at 213.36 64.77)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "aae11a9e-c5e0-4d73-a53d-248de699c4a3")
-	)
-	(junction
-		(at 130.81 100.33)
+		(at 157.48 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "abcdb0d0-94b4-4cc5-a632-23de5d93fa17")
 	)
 	(junction
-		(at 63.5 107.95)
+		(at 63.5 133.35)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "ac4cfe61-0f29-46d2-ba17-62aee577043f")
+		(uuid "aec66786-dd86-4d04-a45d-d2970fb61bc0")
 	)
 	(junction
-		(at 245.11 67.31)
+		(at 257.81 67.31)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c4ecfdce-6512-4d84-b8fc-1069a8acd56f")
 	)
 	(junction
-		(at 147.32 71.12)
+		(at 173.99 71.12)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "cb4d51a7-4bec-44fe-a7fd-ea304529732b")
 	)
 	(junction
-		(at 172.72 71.12)
+		(at 199.39 71.12)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "cd45eacf-dd4b-447d-915a-ff112a50087e")
 	)
 	(junction
-		(at 172.72 67.31)
+		(at 199.39 67.31)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d422d8f8-e13e-4112-aab9-1d5701fb4960")
 	)
+	(junction
+		(at 118.11 118.11)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dad030f8-933a-42b6-ab7a-67bf371c7c20")
+	)
 	(wire
 		(pts
-			(xy 153.67 24.13) (xy 156.21 24.13)
+			(xy 87.63 107.95) (xy 87.63 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "00a0a9e5-dea8-4c5e-91e1-16b71669322d")
+	)
+	(wire
+		(pts
+			(xy 180.34 24.13) (xy 182.88 24.13)
 		)
 		(stroke
 			(width 0)
@@ -2985,7 +3025,17 @@
 	)
 	(wire
 		(pts
-			(xy 172.72 71.12) (xy 172.72 74.93)
+			(xy 63.5 110.49) (xy 67.31 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0786a5b9-d709-4913-868b-450ddc77b977")
+	)
+	(wire
+		(pts
+			(xy 199.39 71.12) (xy 199.39 74.93)
 		)
 		(stroke
 			(width 0)
@@ -2995,7 +3045,7 @@
 	)
 	(wire
 		(pts
-			(xy 213.36 74.93) (xy 213.36 80.01)
+			(xy 236.22 74.93) (xy 236.22 80.01)
 		)
 		(stroke
 			(width 0)
@@ -3005,7 +3055,7 @@
 	)
 	(wire
 		(pts
-			(xy 152.4 86.36) (xy 147.32 86.36)
+			(xy 179.07 86.36) (xy 173.99 86.36)
 		)
 		(stroke
 			(width 0)
@@ -3015,7 +3065,7 @@
 	)
 	(wire
 		(pts
-			(xy 147.32 71.12) (xy 149.86 71.12)
+			(xy 173.99 71.12) (xy 176.53 71.12)
 		)
 		(stroke
 			(width 0)
@@ -3025,7 +3075,7 @@
 	)
 	(wire
 		(pts
-			(xy 204.47 39.37) (xy 212.09 39.37)
+			(xy 231.14 39.37) (xy 237.49 39.37)
 		)
 		(stroke
 			(width 0)
@@ -3035,7 +3085,7 @@
 	)
 	(wire
 		(pts
-			(xy 223.52 76.2) (xy 245.11 76.2)
+			(xy 238.76 76.2) (xy 257.81 76.2)
 		)
 		(stroke
 			(width 0)
@@ -3045,7 +3095,7 @@
 	)
 	(wire
 		(pts
-			(xy 181.61 44.45) (xy 181.61 48.26)
+			(xy 208.28 44.45) (xy 208.28 48.26)
 		)
 		(stroke
 			(width 0)
@@ -3055,7 +3105,27 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 99.06) (xy 100.33 100.33)
+			(xy 100.33 107.95) (xy 101.6 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10892d6e-45ac-4de9-bbee-cf15dc995a5b")
+	)
+	(wire
+		(pts
+			(xy 69.85 105.41) (xy 69.85 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "139ceb39-e300-4825-9015-a95a38dd7a9b")
+	)
+	(wire
+		(pts
+			(xy 127 99.06) (xy 127 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3065,7 +3135,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 64.77) (xy 203.2 64.77)
+			(xy 226.06 64.77) (xy 227.33 64.77)
 		)
 		(stroke
 			(width 0)
@@ -3075,7 +3145,7 @@
 	)
 	(wire
 		(pts
-			(xy 166.37 35.56) (xy 166.37 39.37)
+			(xy 193.04 35.56) (xy 193.04 39.37)
 		)
 		(stroke
 			(width 0)
@@ -3085,7 +3155,7 @@
 	)
 	(wire
 		(pts
-			(xy 176.53 20.32) (xy 176.53 24.13)
+			(xy 203.2 20.32) (xy 203.2 24.13)
 		)
 		(stroke
 			(width 0)
@@ -3105,7 +3175,7 @@
 	)
 	(wire
 		(pts
-			(xy 176.53 62.23) (xy 184.15 62.23)
+			(xy 203.2 62.23) (xy 210.82 62.23)
 		)
 		(stroke
 			(width 0)
@@ -3115,7 +3185,7 @@
 	)
 	(wire
 		(pts
-			(xy 166.37 24.13) (xy 176.53 24.13)
+			(xy 193.04 24.13) (xy 203.2 24.13)
 		)
 		(stroke
 			(width 0)
@@ -3125,7 +3195,7 @@
 	)
 	(wire
 		(pts
-			(xy 176.53 24.13) (xy 193.04 24.13)
+			(xy 203.2 24.13) (xy 219.71 24.13)
 		)
 		(stroke
 			(width 0)
@@ -3135,7 +3205,7 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 100.33) (xy 130.81 105.41)
+			(xy 157.48 100.33) (xy 157.48 105.41)
 		)
 		(stroke
 			(width 0)
@@ -3145,7 +3215,7 @@
 	)
 	(wire
 		(pts
-			(xy 226.06 69.85) (xy 223.52 69.85)
+			(xy 240.03 69.85) (xy 238.76 69.85)
 		)
 		(stroke
 			(width 0)
@@ -3155,7 +3225,7 @@
 	)
 	(wire
 		(pts
-			(xy 241.3 67.31) (xy 245.11 67.31)
+			(xy 255.27 67.31) (xy 257.81 67.31)
 		)
 		(stroke
 			(width 0)
@@ -3165,7 +3235,7 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 100.33) (xy 134.62 100.33)
+			(xy 157.48 100.33) (xy 161.29 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3175,7 +3245,7 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 100.33) (xy 110.49 100.33)
+			(xy 127 100.33) (xy 137.16 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3185,7 +3255,7 @@
 	)
 	(wire
 		(pts
-			(xy 151.13 24.13) (xy 153.67 24.13)
+			(xy 177.8 24.13) (xy 180.34 24.13)
 		)
 		(stroke
 			(width 0)
@@ -3195,7 +3265,7 @@
 	)
 	(wire
 		(pts
-			(xy 147.32 77.47) (xy 147.32 71.12)
+			(xy 173.99 77.47) (xy 173.99 71.12)
 		)
 		(stroke
 			(width 0)
@@ -3205,7 +3275,17 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 86.36) (xy 130.81 100.33)
+			(xy 81.28 116.84) (xy 87.63 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34d33e19-9b48-44ac-997a-e2c3932e15af")
+	)
+	(wire
+		(pts
+			(xy 157.48 86.36) (xy 157.48 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3225,7 +3305,7 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 93.98) (xy 110.49 100.33)
+			(xy 137.16 93.98) (xy 137.16 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3235,7 +3315,17 @@
 	)
 	(wire
 		(pts
-			(xy 190.5 39.37) (xy 190.5 29.21)
+			(xy 85.09 107.95) (xy 87.63 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a4fa1f5-b770-4b85-9a11-ac474a67f434")
+	)
+	(wire
+		(pts
+			(xy 217.17 39.37) (xy 217.17 29.21)
 		)
 		(stroke
 			(width 0)
@@ -3245,7 +3335,17 @@
 	)
 	(wire
 		(pts
-			(xy 213.36 64.77) (xy 213.36 67.31)
+			(xy 99.06 88.9) (xy 104.14 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b21f601-1096-415d-be89-b0b789ab6fb4")
+	)
+	(wire
+		(pts
+			(xy 236.22 64.77) (xy 236.22 67.31)
 		)
 		(stroke
 			(width 0)
@@ -3275,7 +3375,7 @@
 	)
 	(wire
 		(pts
-			(xy 212.09 39.37) (xy 212.09 26.67)
+			(xy 237.49 39.37) (xy 237.49 26.67)
 		)
 		(stroke
 			(width 0)
@@ -3295,7 +3395,7 @@
 	)
 	(wire
 		(pts
-			(xy 224.79 26.67) (xy 232.41 26.67)
+			(xy 247.65 26.67) (xy 251.46 26.67)
 		)
 		(stroke
 			(width 0)
@@ -3305,7 +3405,7 @@
 	)
 	(wire
 		(pts
-			(xy 208.28 26.67) (xy 212.09 26.67)
+			(xy 234.95 26.67) (xy 237.49 26.67)
 		)
 		(stroke
 			(width 0)
@@ -3325,7 +3425,7 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 102.87) (xy 118.11 100.33)
+			(xy 144.78 102.87) (xy 144.78 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3345,7 +3445,7 @@
 	)
 	(wire
 		(pts
-			(xy 133.35 30.48) (xy 153.67 30.48)
+			(xy 160.02 30.48) (xy 180.34 30.48)
 		)
 		(stroke
 			(width 0)
@@ -3355,7 +3455,17 @@
 	)
 	(wire
 		(pts
-			(xy 172.72 71.12) (xy 184.15 71.12)
+			(xy 67.31 116.84) (xy 67.31 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5146822f-690b-4792-aa45-36346832661d")
+	)
+	(wire
+		(pts
+			(xy 199.39 71.12) (xy 210.82 71.12)
 		)
 		(stroke
 			(width 0)
@@ -3365,7 +3475,7 @@
 	)
 	(wire
 		(pts
-			(xy 223.52 69.85) (xy 223.52 76.2)
+			(xy 238.76 69.85) (xy 238.76 76.2)
 		)
 		(stroke
 			(width 0)
@@ -3375,7 +3485,7 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 113.03) (xy 130.81 115.57)
+			(xy 157.48 113.03) (xy 157.48 115.57)
 		)
 		(stroke
 			(width 0)
@@ -3395,7 +3505,7 @@
 	)
 	(wire
 		(pts
-			(xy 153.67 30.48) (xy 153.67 24.13)
+			(xy 180.34 30.48) (xy 180.34 24.13)
 		)
 		(stroke
 			(width 0)
@@ -3415,7 +3525,7 @@
 	)
 	(wire
 		(pts
-			(xy 135.89 21.59) (xy 130.81 21.59)
+			(xy 162.56 21.59) (xy 157.48 21.59)
 		)
 		(stroke
 			(width 0)
@@ -3445,23 +3555,13 @@
 	)
 	(wire
 		(pts
-			(xy 149.86 100.33) (xy 152.4 100.33)
+			(xy 176.53 100.33) (xy 179.07 100.33)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "6814a0a5-60e6-484b-80cb-68c027ee4774")
-	)
-	(wire
-		(pts
-			(xy 82.55 107.95) (xy 92.71 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6abca6d2-1e0d-45e2-9ab5-0be5f06b00ee")
 	)
 	(wire
 		(pts
@@ -3475,7 +3575,7 @@
 	)
 	(wire
 		(pts
-			(xy 153.67 74.93) (xy 153.67 77.47)
+			(xy 180.34 74.93) (xy 180.34 77.47)
 		)
 		(stroke
 			(width 0)
@@ -3485,7 +3585,7 @@
 	)
 	(wire
 		(pts
-			(xy 82.55 129.54) (xy 82.55 132.08)
+			(xy 118.11 132.08) (xy 118.11 134.62)
 		)
 		(stroke
 			(width 0)
@@ -3495,17 +3595,17 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 107.95) (xy 63.5 133.35)
+			(xy 97.79 107.95) (xy 100.33 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "743be25a-67e6-4612-9d29-13d906601984")
+		(uuid "7484ce42-8e99-441f-9561-d2dfe2b69f53")
 	)
 	(wire
 		(pts
-			(xy 157.48 71.12) (xy 161.29 71.12)
+			(xy 184.15 71.12) (xy 187.96 71.12)
 		)
 		(stroke
 			(width 0)
@@ -3525,7 +3625,7 @@
 	)
 	(wire
 		(pts
-			(xy 153.67 77.47) (xy 147.32 77.47)
+			(xy 180.34 77.47) (xy 173.99 77.47)
 		)
 		(stroke
 			(width 0)
@@ -3535,7 +3635,7 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 100.33) (xy 100.33 102.87)
+			(xy 127 100.33) (xy 127 102.87)
 		)
 		(stroke
 			(width 0)
@@ -3555,7 +3655,7 @@
 	)
 	(wire
 		(pts
-			(xy 163.83 24.13) (xy 166.37 24.13)
+			(xy 190.5 24.13) (xy 193.04 24.13)
 		)
 		(stroke
 			(width 0)
@@ -3565,7 +3665,7 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 40.64) (xy 143.51 45.72)
+			(xy 170.18 40.64) (xy 170.18 45.72)
 		)
 		(stroke
 			(width 0)
@@ -3575,7 +3675,7 @@
 	)
 	(wire
 		(pts
-			(xy 133.35 26.67) (xy 133.35 30.48)
+			(xy 160.02 26.67) (xy 160.02 30.48)
 		)
 		(stroke
 			(width 0)
@@ -3585,7 +3685,7 @@
 	)
 	(wire
 		(pts
-			(xy 193.04 29.21) (xy 190.5 29.21)
+			(xy 219.71 29.21) (xy 217.17 29.21)
 		)
 		(stroke
 			(width 0)
@@ -3595,13 +3695,33 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 86.36) (xy 100.33 91.44)
+			(xy 118.11 105.41) (xy 116.84 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "827380bd-8c3e-416e-ae0c-8721238cb4a0")
+	)
+	(wire
+		(pts
+			(xy 127 86.36) (xy 127 91.44)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "82cee2bf-982b-4aee-91f3-e4068a33d8a8")
+	)
+	(wire
+		(pts
+			(xy 236.22 64.77) (xy 240.03 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8b3a7544-19b0-47c4-b0ff-23527f2edea5")
 	)
 	(wire
 		(pts
@@ -3615,7 +3735,7 @@
 	)
 	(wire
 		(pts
-			(xy 245.11 67.31) (xy 245.11 76.2)
+			(xy 257.81 67.31) (xy 257.81 76.2)
 		)
 		(stroke
 			(width 0)
@@ -3625,7 +3745,7 @@
 	)
 	(wire
 		(pts
-			(xy 166.37 24.13) (xy 166.37 27.94)
+			(xy 193.04 24.13) (xy 193.04 27.94)
 		)
 		(stroke
 			(width 0)
@@ -3635,7 +3755,7 @@
 	)
 	(wire
 		(pts
-			(xy 210.82 64.77) (xy 213.36 64.77)
+			(xy 234.95 64.77) (xy 236.22 64.77)
 		)
 		(stroke
 			(width 0)
@@ -3645,17 +3765,17 @@
 	)
 	(wire
 		(pts
-			(xy 82.55 107.95) (xy 63.5 107.95)
+			(xy 100.33 118.11) (xy 100.33 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "95244c9a-ad19-46dd-8e52-c4f5072405ac")
+		(uuid "96ccb288-08a0-4211-9d1c-04453028ecd5")
 	)
 	(wire
 		(pts
-			(xy 139.7 86.36) (xy 130.81 86.36)
+			(xy 166.37 86.36) (xy 157.48 86.36)
 		)
 		(stroke
 			(width 0)
@@ -3665,7 +3785,27 @@
 	)
 	(wire
 		(pts
-			(xy 135.89 26.67) (xy 133.35 26.67)
+			(xy 63.5 110.49) (xy 63.5 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "99fe59f8-86b7-4156-92c4-b7ccb1370f79")
+	)
+	(wire
+		(pts
+			(xy 237.49 26.67) (xy 240.03 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a94c58b-e3fb-4ac9-acdb-c9c344b5bdf4")
+	)
+	(wire
+		(pts
+			(xy 162.56 26.67) (xy 160.02 26.67)
 		)
 		(stroke
 			(width 0)
@@ -3675,7 +3815,17 @@
 	)
 	(wire
 		(pts
-			(xy 157.48 49.53) (xy 172.72 49.53)
+			(xy 63.5 107.95) (xy 63.5 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9b6da40d-0919-469c-bb3b-75242c6a6e7c")
+	)
+	(wire
+		(pts
+			(xy 184.15 49.53) (xy 199.39 49.53)
 		)
 		(stroke
 			(width 0)
@@ -3685,7 +3835,27 @@
 	)
 	(wire
 		(pts
-			(xy 110.49 100.33) (xy 110.49 107.95)
+			(xy 67.31 116.84) (xy 73.66 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9ce73ca3-f476-450f-be98-841a6b45f449")
+	)
+	(wire
+		(pts
+			(xy 118.11 107.95) (xy 119.38 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d77140e-ee74-47c0-a380-5a62a0a178f9")
+	)
+	(wire
+		(pts
+			(xy 137.16 100.33) (xy 137.16 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3695,7 +3865,7 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 53.34) (xy 143.51 57.15)
+			(xy 170.18 53.34) (xy 170.18 57.15)
 		)
 		(stroke
 			(width 0)
@@ -3735,7 +3905,7 @@
 	)
 	(wire
 		(pts
-			(xy 181.61 29.21) (xy 181.61 36.83)
+			(xy 208.28 29.21) (xy 208.28 36.83)
 		)
 		(stroke
 			(width 0)
@@ -3775,7 +3945,17 @@
 	)
 	(wire
 		(pts
-			(xy 125.73 86.36) (xy 130.81 86.36)
+			(xy 118.11 118.11) (xy 118.11 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "adf01041-1292-40cf-b7dc-65a52c3ea69b")
+	)
+	(wire
+		(pts
+			(xy 152.4 86.36) (xy 157.48 86.36)
 		)
 		(stroke
 			(width 0)
@@ -3785,7 +3965,7 @@
 	)
 	(wire
 		(pts
-			(xy 184.15 77.47) (xy 184.15 71.12)
+			(xy 210.82 77.47) (xy 210.82 71.12)
 		)
 		(stroke
 			(width 0)
@@ -3795,7 +3975,17 @@
 	)
 	(wire
 		(pts
-			(xy 147.32 49.53) (xy 149.86 49.53)
+			(xy 69.85 88.9) (xy 76.2 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b09cb931-8575-423f-9251-3f6344a7d602")
+	)
+	(wire
+		(pts
+			(xy 173.99 49.53) (xy 176.53 49.53)
 		)
 		(stroke
 			(width 0)
@@ -3815,7 +4005,7 @@
 	)
 	(wire
 		(pts
-			(xy 172.72 82.55) (xy 172.72 86.36)
+			(xy 199.39 82.55) (xy 199.39 86.36)
 		)
 		(stroke
 			(width 0)
@@ -3825,17 +4015,17 @@
 	)
 	(wire
 		(pts
-			(xy 82.55 107.95) (xy 82.55 110.49)
+			(xy 115.57 118.11) (xy 118.11 118.11)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b61b8f38-6f97-4dac-8eeb-28284302417f")
+		(uuid "b634096e-d0bf-4b0b-8f35-b7f96ce2f895")
 	)
 	(wire
 		(pts
-			(xy 245.11 67.31) (xy 248.92 67.31)
+			(xy 257.81 67.31) (xy 260.35 67.31)
 		)
 		(stroke
 			(width 0)
@@ -3845,7 +4035,17 @@
 	)
 	(wire
 		(pts
-			(xy 256.54 67.31) (xy 265.43 67.31)
+			(xy 107.95 118.11) (xy 100.33 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b96da18c-6bb9-4607-bed2-e763fa8063f0")
+	)
+	(wire
+		(pts
+			(xy 267.97 67.31) (xy 271.78 67.31)
 		)
 		(stroke
 			(width 0)
@@ -3855,17 +4055,7 @@
 	)
 	(wire
 		(pts
-			(xy 212.09 26.67) (xy 217.17 26.67)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "beb7d279-9cd1-4cda-917b-43bd2735868d")
-	)
-	(wire
-		(pts
-			(xy 172.72 49.53) (xy 172.72 67.31)
+			(xy 199.39 49.53) (xy 199.39 67.31)
 		)
 		(stroke
 			(width 0)
@@ -3885,7 +4075,7 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 100.33) (xy 130.81 100.33)
+			(xy 144.78 100.33) (xy 157.48 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3905,16 +4095,6 @@
 	)
 	(wire
 		(pts
-			(xy 82.55 118.11) (xy 82.55 120.65)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "c7b90ec6-cad5-4b43-af6f-ceea10c475ab")
-	)
-	(wire
-		(pts
 			(xy 40.64 152.4) (xy 43.18 152.4)
 		)
 		(stroke
@@ -3925,7 +4105,7 @@
 	)
 	(wire
 		(pts
-			(xy 190.5 29.21) (xy 181.61 29.21)
+			(xy 217.17 29.21) (xy 208.28 29.21)
 		)
 		(stroke
 			(width 0)
@@ -3935,13 +4115,33 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 113.03) (xy 118.11 115.57)
+			(xy 118.11 107.95) (xy 118.11 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd8938b6-21f4-47a7-9619-5f5eb208a997")
+	)
+	(wire
+		(pts
+			(xy 144.78 113.03) (xy 144.78 115.57)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "cddf9a3f-741b-4f0c-8c2e-d8901c6781cf")
+	)
+	(wire
+		(pts
+			(xy 101.6 102.87) (xy 99.06 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d133aa6a-56eb-495c-9f9b-d7e25edb655d")
 	)
 	(wire
 		(pts
@@ -3965,13 +4165,13 @@
 	)
 	(wire
 		(pts
-			(xy 213.36 64.77) (xy 226.06 64.77)
+			(xy 87.63 107.95) (xy 90.17 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "da0d94aa-9800-4704-ae67-a7200d8db7ed")
+		(uuid "d7142958-03f2-4b49-8521-cc44403221dc")
 	)
 	(wire
 		(pts
@@ -3995,7 +4195,7 @@
 	)
 	(wire
 		(pts
-			(xy 172.72 67.31) (xy 184.15 67.31)
+			(xy 199.39 67.31) (xy 210.82 67.31)
 		)
 		(stroke
 			(width 0)
@@ -4005,7 +4205,7 @@
 	)
 	(wire
 		(pts
-			(xy 152.4 100.33) (xy 152.4 86.36)
+			(xy 179.07 100.33) (xy 179.07 86.36)
 		)
 		(stroke
 			(width 0)
@@ -4015,7 +4215,17 @@
 	)
 	(wire
 		(pts
-			(xy 176.53 24.13) (xy 176.53 62.23)
+			(xy 118.11 118.11) (xy 118.11 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e0a524e7-585d-492b-ac14-fdf0f9e607e4")
+	)
+	(wire
+		(pts
+			(xy 203.2 24.13) (xy 203.2 62.23)
 		)
 		(stroke
 			(width 0)
@@ -4035,7 +4245,7 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 21.59) (xy 130.81 86.36)
+			(xy 157.48 21.59) (xy 157.48 86.36)
 		)
 		(stroke
 			(width 0)
@@ -4045,7 +4255,7 @@
 	)
 	(wire
 		(pts
-			(xy 172.72 67.31) (xy 172.72 71.12)
+			(xy 199.39 67.31) (xy 199.39 71.12)
 		)
 		(stroke
 			(width 0)
@@ -4055,7 +4265,7 @@
 	)
 	(wire
 		(pts
-			(xy 168.91 71.12) (xy 172.72 71.12)
+			(xy 195.58 71.12) (xy 199.39 71.12)
 		)
 		(stroke
 			(width 0)
@@ -4065,7 +4275,7 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 113.03) (xy 100.33 115.57)
+			(xy 127 113.03) (xy 127 115.57)
 		)
 		(stroke
 			(width 0)
@@ -4075,13 +4285,23 @@
 	)
 	(wire
 		(pts
-			(xy 82.55 128.27) (xy 82.55 129.54)
+			(xy 118.11 130.81) (xy 118.11 132.08)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "e6e1e978-0793-4d4e-ad7f-709f62dfa7f3")
+	)
+	(wire
+		(pts
+			(xy 99.06 102.87) (xy 99.06 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e76ecc14-e9f5-4b67-881c-fe966c1bcaf2")
 	)
 	(wire
 		(pts
@@ -4105,6 +4325,16 @@
 	)
 	(wire
 		(pts
+			(xy 67.31 110.49) (xy 69.85 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec6517a2-8a39-48c1-8ebf-17131ddef4b1")
+	)
+	(wire
+		(pts
 			(xy 50.8 133.35) (xy 53.34 133.35)
 		)
 		(stroke
@@ -4115,7 +4345,7 @@
 	)
 	(wire
 		(pts
-			(xy 78.74 124.46) (xy 78.74 129.54)
+			(xy 114.3 127) (xy 114.3 132.08)
 		)
 		(stroke
 			(width 0)
@@ -4125,7 +4355,7 @@
 	)
 	(wire
 		(pts
-			(xy 144.78 71.12) (xy 147.32 71.12)
+			(xy 171.45 71.12) (xy 173.99 71.12)
 		)
 		(stroke
 			(width 0)
@@ -4135,7 +4365,7 @@
 	)
 	(wire
 		(pts
-			(xy 78.74 129.54) (xy 82.55 129.54)
+			(xy 114.3 132.08) (xy 118.11 132.08)
 		)
 		(stroke
 			(width 0)
@@ -4155,7 +4385,7 @@
 	)
 	(wire
 		(pts
-			(xy 196.85 39.37) (xy 190.5 39.37)
+			(xy 223.52 39.37) (xy 217.17 39.37)
 		)
 		(stroke
 			(width 0)
@@ -4174,19 +4404,7 @@
 		(uuid "fd8084d3-ff94-4c24-8174-321305e91580")
 	)
 	(circle
-		(center 83.82 113.03)
-		(radius 6.8392)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(fill
-			(type none)
-		)
-		(uuid 0ebad27a-2b59-4b0f-a226-1a0db307c860)
-	)
-	(circle
-		(center 176.022 80.772)
+		(center 202.692 80.772)
 		(radius 6.8392)
 		(stroke
 			(width 0)
@@ -4210,7 +4428,7 @@
 		(uuid 39165d86-ba24-4f26-a39b-a36c41f539fb)
 	)
 	(circle
-		(center 153.162 69.342)
+		(center 179.832 69.342)
 		(radius 6.8392)
 		(stroke
 			(width 0)
@@ -4223,7 +4441,7 @@
 	)
 	(text "used 100k for now"
 		(exclude_from_sim no)
-		(at 154.432 76.962 0)
+		(at 181.102 76.962 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4231,19 +4449,9 @@
 		)
 		(uuid "09690317-5714-412a-a1bf-9b2a232140d1")
 	)
-	(text "used 1k + 510R for now"
-		(exclude_from_sim no)
-		(at 83.058 104.648 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-		)
-		(uuid "4867adaf-e0db-43b9-a426-0194b0d8b551")
-	)
 	(text "Cermet trimpots pinout:\nwhen viewing the trimpot from above,\n1 = left = fully CCW\n2 = middle\n3 = rigth = fully CW"
 		(exclude_from_sim no)
-		(at 92.202 149.098 0)
+		(at 134.112 154.94 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4253,7 +4461,7 @@
 	)
 	(text "used 10k for now,\nmight need trimpot"
 		(exclude_from_sim no)
-		(at 171.958 83.82 0)
+		(at 198.628 83.82 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4296,7 +4504,7 @@
 	)
 	(hierarchical_label "Sawtooth Out"
 		(shape output)
-		(at 232.41 26.67 0)
+		(at 251.46 26.67 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4308,7 +4516,7 @@
 	)
 	(hierarchical_label "PW Mod In"
 		(shape input)
-		(at 144.78 71.12 180)
+		(at 171.45 71.12 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4344,7 +4552,7 @@
 	)
 	(hierarchical_label "Square Out"
 		(shape output)
-		(at 265.43 67.31 0)
+		(at 271.78 67.31 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4436,7 +4644,7 @@
 	)
 	(symbol
 		(lib_id "power:+12V")
-		(at 143.51 40.64 0)
+		(at 170.18 40.64 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4445,7 +4653,7 @@
 		(fields_autoplaced yes)
 		(uuid "091bfedf-6f97-41e3-aa55-33f7b5241cba")
 		(property "Reference" "#PWR026"
-			(at 143.51 44.45 0)
+			(at 170.18 44.45 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4454,7 +4662,7 @@
 			)
 		)
 		(property "Value" "+12V"
-			(at 143.51 35.56 0)
+			(at 170.18 35.56 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4462,7 +4670,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 143.51 40.64 0)
+			(at 170.18 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4471,7 +4679,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 143.51 40.64 0)
+			(at 170.18 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4480,7 +4688,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+12V\""
-			(at 143.51 40.64 0)
+			(at 170.18 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4502,7 +4710,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 118.11 115.57 0)
+		(at 144.78 115.57 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4511,7 +4719,7 @@
 		(fields_autoplaced yes)
 		(uuid "0ca7b7ef-9640-4f9c-b711-82537a7cde8e")
 		(property "Reference" "#PWR022"
-			(at 118.11 121.92 0)
+			(at 144.78 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4520,7 +4728,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 118.11 120.65 0)
+			(at 144.78 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4528,7 +4736,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 118.11 115.57 0)
+			(at 144.78 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4537,7 +4745,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 118.11 115.57 0)
+			(at 144.78 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4546,7 +4754,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 118.11 115.57 0)
+			(at 144.78 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4568,7 +4776,7 @@
 	)
 	(symbol
 		(lib_id "Connector:TestPoint")
-		(at 176.53 20.32 0)
+		(at 203.2 20.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4577,7 +4785,7 @@
 		(fields_autoplaced yes)
 		(uuid "0cdfebb4-db16-4913-956a-8b8f13c8539e")
 		(property "Reference" "TP3"
-			(at 179.07 15.7479 0)
+			(at 205.74 15.7479 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4586,7 +4794,7 @@
 			)
 		)
 		(property "Value" "TestPoint"
-			(at 179.07 18.2879 0)
+			(at 205.74 18.2879 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4595,7 +4803,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 181.61 20.32 0)
+			(at 208.28 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4604,7 +4812,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 181.61 20.32 0)
+			(at 208.28 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4613,7 +4821,7 @@
 			)
 		)
 		(property "Description" "test point"
-			(at 176.53 20.32 0)
+			(at 203.2 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4635,7 +4843,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 172.72 78.74 0)
+		(at 199.39 78.74 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4644,7 +4852,7 @@
 		(fields_autoplaced yes)
 		(uuid "131f8aaf-78c0-407e-a103-1dd82ffe84d2")
 		(property "Reference" "R15"
-			(at 175.26 77.4699 0)
+			(at 201.93 77.4699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4653,7 +4861,7 @@
 			)
 		)
 		(property "Value" "14k"
-			(at 175.26 80.0099 0)
+			(at 201.93 80.0099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4662,7 +4870,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 173.736 78.994 90)
+			(at 200.406 78.994 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4671,7 +4879,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 172.72 78.74 0)
+			(at 199.39 78.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4680,7 +4888,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 172.72 78.74 0)
+			(at 199.39 78.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4705,16 +4913,15 @@
 	)
 	(symbol
 		(lib_id "power:-12V")
-		(at 100.33 115.57 180)
+		(at 127 115.57 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "1566cf2a-5fd2-49eb-98d6-b14774fd127a")
 		(property "Reference" "#PWR021"
-			(at 100.33 111.76 0)
+			(at 127 111.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4723,7 +4930,7 @@
 			)
 		)
 		(property "Value" "-12V"
-			(at 100.33 120.65 0)
+			(at 127 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4731,7 +4938,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 100.33 115.57 0)
+			(at 127 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4740,7 +4947,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 100.33 115.57 0)
+			(at 127 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4749,7 +4956,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 100.33 115.57 0)
+			(at 127 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4839,7 +5046,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 172.72 86.36 0)
+		(at 199.39 86.36 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4848,7 +5055,7 @@
 		(fields_autoplaced yes)
 		(uuid "16dc414e-558a-41ea-90fb-93a2a3dcf463")
 		(property "Reference" "#PWR027"
-			(at 172.72 92.71 0)
+			(at 199.39 92.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4857,7 +5064,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 172.72 91.44 0)
+			(at 199.39 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4865,7 +5072,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 172.72 86.36 0)
+			(at 199.39 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4874,7 +5081,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 172.72 86.36 0)
+			(at 199.39 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4883,7 +5090,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 172.72 86.36 0)
+			(at 199.39 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4905,7 +5112,7 @@
 	)
 	(symbol
 		(lib_id "Amplifier_Operational:TL074")
-		(at 200.66 26.67 0)
+		(at 227.33 26.67 0)
 		(unit 2)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4914,7 +5121,7 @@
 		(fields_autoplaced yes)
 		(uuid "19f73e36-9b99-4ce3-909f-ab870288fd9e")
 		(property "Reference" "U2"
-			(at 200.66 16.51 0)
+			(at 227.33 16.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4922,7 +5129,7 @@
 			)
 		)
 		(property "Value" "TL074"
-			(at 200.66 19.05 0)
+			(at 227.33 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4930,7 +5137,7 @@
 			)
 		)
 		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
-			(at 199.39 24.13 0)
+			(at 226.06 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4939,7 +5146,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
-			(at 201.93 21.59 0)
+			(at 228.6 21.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4948,7 +5155,7 @@
 			)
 		)
 		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
-			(at 200.66 26.67 0)
+			(at 227.33 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5009,7 +5216,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 130.81 115.57 0)
+		(at 157.48 115.57 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5018,7 +5225,7 @@
 		(fields_autoplaced yes)
 		(uuid "21cfe5fd-cec7-4f4b-ab52-4d35a646f99f")
 		(property "Reference" "#PWR023"
-			(at 130.81 121.92 0)
+			(at 157.48 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5027,7 +5234,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 130.81 120.65 0)
+			(at 157.48 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5035,7 +5242,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 130.81 115.57 0)
+			(at 157.48 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5044,7 +5251,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 130.81 115.57 0)
+			(at 157.48 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5053,7 +5260,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 130.81 115.57 0)
+			(at 157.48 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5074,17 +5281,83 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R_US")
-		(at 213.36 71.12 0)
+		(lib_id "power:GND")
+		(at 76.2 88.9 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
+		(uuid "22bbb18e-5ee8-4a3a-81b9-79d7cfe6f704")
+		(property "Reference" "#PWR041"
+			(at 76.2 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 76.2 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 76.2 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 76.2 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 76.2 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "70bf0f84-6d38-48ea-abc7-920b798270e1")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "#PWR041")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
+		(at 236.22 71.12 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
 		(uuid "2c82c8c8-64dc-476e-a514-ad80963d0d6a")
 		(property "Reference" "R19"
-			(at 215.9 69.8499 0)
+			(at 233.68 69.8499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5093,7 +5366,7 @@
 			)
 		)
 		(property "Value" "68k"
-			(at 215.9 72.3899 0)
+			(at 233.68 72.3899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5102,7 +5375,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 214.376 71.374 90)
+			(at 235.204 71.374 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5111,7 +5384,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 213.36 71.12 0)
+			(at 236.22 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5120,7 +5393,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 213.36 71.12 0)
+			(at 236.22 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5145,7 +5418,7 @@
 	)
 	(symbol
 		(lib_id "Diode:1N4148")
-		(at 143.51 86.36 0)
+		(at 170.18 86.36 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5154,7 +5427,7 @@
 		(fields_autoplaced yes)
 		(uuid "2e4cadcf-0bf0-4c04-856d-5eaff7197f22")
 		(property "Reference" "D1"
-			(at 143.51 80.01 0)
+			(at 170.18 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5162,7 +5435,7 @@
 			)
 		)
 		(property "Value" "1N4148"
-			(at 143.51 82.55 0)
+			(at 170.18 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5170,7 +5443,7 @@
 			)
 		)
 		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
-			(at 143.51 86.36 0)
+			(at 170.18 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5179,7 +5452,7 @@
 			)
 		)
 		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
-			(at 143.51 86.36 0)
+			(at 170.18 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5188,7 +5461,7 @@
 			)
 		)
 		(property "Description" "100V 0.15A standard switching diode, DO-35"
-			(at 143.51 86.36 0)
+			(at 170.18 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5197,7 +5470,7 @@
 			)
 		)
 		(property "Sim.Device" "D"
-			(at 143.51 86.36 0)
+			(at 170.18 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5206,7 +5479,7 @@
 			)
 		)
 		(property "Sim.Pins" "1=K 2=A"
-			(at 143.51 86.36 0)
+			(at 170.18 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5231,7 +5504,7 @@
 	)
 	(symbol
 		(lib_id "4xxx:40106")
-		(at 142.24 100.33 0)
+		(at 168.91 100.33 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5240,7 +5513,7 @@
 		(fields_autoplaced yes)
 		(uuid "34c6e944-a382-46e7-a2d0-845c90207784")
 		(property "Reference" "U1"
-			(at 142.24 91.44 0)
+			(at 168.91 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5248,7 +5521,7 @@
 			)
 		)
 		(property "Value" "40106"
-			(at 142.24 93.98 0)
+			(at 168.91 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5256,7 +5529,7 @@
 			)
 		)
 		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
-			(at 142.24 100.33 0)
+			(at 168.91 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5265,7 +5538,7 @@
 			)
 		)
 		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/HEF40106B.pdf"
-			(at 142.24 100.33 0)
+			(at 168.91 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5274,7 +5547,7 @@
 			)
 		)
 		(property "Description" "Hex Schmitt trigger inverter"
-			(at 142.24 100.33 0)
+			(at 168.91 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5335,7 +5608,7 @@
 	)
 	(symbol
 		(lib_id "Amplifier_Operational:TL074")
-		(at 143.51 24.13 0)
+		(at 170.18 24.13 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5344,7 +5617,7 @@
 		(fields_autoplaced yes)
 		(uuid "36907186-b1af-4038-a3ea-e0d6c6a0db6e")
 		(property "Reference" "U2"
-			(at 143.51 13.97 0)
+			(at 170.18 13.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5352,7 +5625,7 @@
 			)
 		)
 		(property "Value" "TL074"
-			(at 143.51 16.51 0)
+			(at 170.18 16.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5360,7 +5633,7 @@
 			)
 		)
 		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
-			(at 142.24 21.59 0)
+			(at 168.91 21.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5369,7 +5642,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
-			(at 144.78 19.05 0)
+			(at 171.45 19.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5378,7 +5651,7 @@
 			)
 		)
 		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
-			(at 143.51 24.13 0)
+			(at 170.18 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5439,7 +5712,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 181.61 48.26 0)
+		(at 208.28 48.26 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5448,7 +5721,7 @@
 		(fields_autoplaced yes)
 		(uuid "399b8b65-33b8-40c8-84fe-30f1e2e52ab9")
 		(property "Reference" "#PWR028"
-			(at 181.61 54.61 0)
+			(at 208.28 54.61 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5457,7 +5730,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 181.61 53.34 0)
+			(at 208.28 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5465,7 +5738,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 181.61 48.26 0)
+			(at 208.28 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5474,7 +5747,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 181.61 48.26 0)
+			(at 208.28 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5483,7 +5756,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 181.61 48.26 0)
+			(at 208.28 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5505,7 +5778,7 @@
 	)
 	(symbol
 		(lib_id "Transistor_BJT:BC558")
-		(at 97.79 107.95 0)
+		(at 124.46 107.95 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -5514,7 +5787,7 @@
 		(dnp no)
 		(uuid "3e8ff1da-4dfe-4f92-b3e8-74f7ebcf7740")
 		(property "Reference" "Q1"
-			(at 102.87 106.6799 0)
+			(at 129.54 106.6799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5523,7 +5796,7 @@
 			)
 		)
 		(property "Value" "BC558"
-			(at 102.87 109.2199 0)
+			(at 129.54 109.2199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5532,7 +5805,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_THT:TO-92_Inline"
-			(at 102.87 106.045 0)
+			(at 129.54 106.045 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5543,7 +5816,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf"
-			(at 97.79 107.95 0)
+			(at 124.46 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5553,7 +5826,7 @@
 			)
 		)
 		(property "Description" "0.1A Ic, 30V Vce, PNP Small Signal Transistor, TO-92"
-			(at 97.79 107.95 0)
+			(at 124.46 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5581,7 +5854,7 @@
 	)
 	(symbol
 		(lib_id "power:+12V")
-		(at 100.33 86.36 0)
+		(at 127 86.36 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5590,7 +5863,7 @@
 		(fields_autoplaced yes)
 		(uuid "42b850ad-20b1-40a6-b969-633b5c42c757")
 		(property "Reference" "#PWR020"
-			(at 100.33 90.17 0)
+			(at 127 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5599,7 +5872,7 @@
 			)
 		)
 		(property "Value" "+12V"
-			(at 100.33 81.28 0)
+			(at 127 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5607,7 +5880,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 100.33 86.36 0)
+			(at 127 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5616,7 +5889,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 100.33 86.36 0)
+			(at 127 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5625,7 +5898,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+12V\""
-			(at 100.33 86.36 0)
+			(at 127 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5646,8 +5919,74 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 104.14 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "50be8e04-ec90-4b4e-802c-824d26aa7f78")
+		(property "Reference" "#PWR042"
+			(at 104.14 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 104.14 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 104.14 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 104.14 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 104.14 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c9fcafe2-aac9-4bfd-97fb-34c66d022e25")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "#PWR042")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R_US")
-		(at 153.67 49.53 270)
+		(at 180.34 49.53 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5656,7 +5995,7 @@
 		(fields_autoplaced yes)
 		(uuid "52a4f955-fa0c-490c-a610-8ae8f7212c10")
 		(property "Reference" "R13"
-			(at 153.67 43.18 90)
+			(at 180.34 43.18 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5664,7 +6003,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 153.67 45.72 90)
+			(at 180.34 45.72 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5672,7 +6011,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 153.416 50.546 90)
+			(at 180.086 50.546 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5681,7 +6020,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 153.67 49.53 0)
+			(at 180.34 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5690,7 +6029,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 153.67 49.53 0)
+			(at 180.34 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5783,7 +6122,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 166.37 39.37 0)
+		(at 193.04 39.37 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5792,7 +6131,7 @@
 		(fields_autoplaced yes)
 		(uuid "56d8f0b5-339b-4599-930d-94bf8acb0726")
 		(property "Reference" "#PWR024"
-			(at 166.37 45.72 0)
+			(at 193.04 45.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5801,7 +6140,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 166.37 44.45 0)
+			(at 193.04 44.45 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5809,7 +6148,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 166.37 39.37 0)
+			(at 193.04 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5818,7 +6157,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 166.37 39.37 0)
+			(at 193.04 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5827,7 +6166,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 166.37 39.37 0)
+			(at 193.04 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5849,7 +6188,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 166.37 31.75 180)
+		(at 193.04 31.75 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5858,7 +6197,7 @@
 		(fields_autoplaced yes)
 		(uuid "57af1864-edee-4351-82fd-aae89a6837f7")
 		(property "Reference" "R12"
-			(at 168.91 30.4799 0)
+			(at 195.58 30.4799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5867,7 +6206,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 168.91 33.0199 0)
+			(at 195.58 33.0199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5876,7 +6215,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 165.354 31.496 90)
+			(at 192.024 31.496 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5885,7 +6224,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 166.37 31.75 0)
+			(at 193.04 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5894,7 +6233,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 166.37 31.75 0)
+			(at 193.04 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5918,8 +6257,76 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R_US")
+		(at 111.76 118.11 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5c63fe45-8305-42e3-8ca7-0d87624a2c69")
+		(property "Reference" "R6"
+			(at 111.76 111.76 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 111.76 114.3 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 112.014 117.094 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 111.76 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 111.76 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "f9bb8a2f-a711-4539-af3a-e0195f2b158b")
+		)
+		(pin "1"
+			(uuid "e86676c6-f442-4a17-be60-725781096bec")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:-12V")
-		(at 143.51 57.15 180)
+		(at 170.18 57.15 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5928,7 +6335,7 @@
 		(fields_autoplaced yes)
 		(uuid "655f2b20-82cc-449e-b94c-225ab8cffa39")
 		(property "Reference" "#PWR025"
-			(at 143.51 53.34 0)
+			(at 170.18 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5937,7 +6344,7 @@
 			)
 		)
 		(property "Value" "-12V"
-			(at 143.51 62.23 0)
+			(at 170.18 62.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5945,7 +6352,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 143.51 57.15 0)
+			(at 170.18 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5954,7 +6361,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 143.51 57.15 0)
+			(at 170.18 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5963,7 +6370,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 143.51 57.15 0)
+			(at 170.18 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6192,7 +6599,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 143.51 49.53 0)
+		(at 170.18 49.53 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -6201,7 +6608,7 @@
 		(dnp no)
 		(uuid "6c76a797-1492-418c-8b33-84bc3d97c3c5")
 		(property "Reference" "RV6"
-			(at 140.97 50.8001 0)
+			(at 167.64 50.8001 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6210,7 +6617,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 140.97 48.2601 0)
+			(at 167.64 48.2601 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6219,7 +6626,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 143.51 49.53 0)
+			(at 170.18 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6228,7 +6635,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 143.51 49.53 0)
+			(at 170.18 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6237,7 +6644,7 @@
 			)
 		)
 		(property "Description" "Pulse Width"
-			(at 134.62 49.53 90)
+			(at 161.29 49.53 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6264,7 +6671,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_Trim_US")
-		(at 82.55 124.46 180)
+		(at 118.11 127 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6272,7 +6679,7 @@
 		(dnp no)
 		(uuid "6d52a498-9f38-4108-b7ea-3c5d9215c1c6")
 		(property "Reference" "RV5"
-			(at 85.09 125.7301 0)
+			(at 120.65 128.2701 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6281,7 +6688,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 85.09 123.1901 0)
+			(at 120.65 125.7301 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6290,7 +6697,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Bourns_3296W_Vertical"
-			(at 82.55 124.46 0)
+			(at 118.11 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6299,7 +6706,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 82.55 124.46 0)
+			(at 118.11 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6308,7 +6715,7 @@
 			)
 		)
 		(property "Description" "V/Oct Calibration"
-			(at 91.186 124.46 90)
+			(at 112.014 136.144 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6403,7 +6810,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 160.02 24.13 90)
+		(at 186.69 24.13 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6412,7 +6819,7 @@
 		(fields_autoplaced yes)
 		(uuid "70610cd3-f9ce-4a27-bee8-ea2c0daee037")
 		(property "Reference" "C11"
-			(at 160.02 16.51 90)
+			(at 186.69 16.51 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6420,7 +6827,7 @@
 			)
 		)
 		(property "Value" "1uF"
-			(at 160.02 19.05 90)
+			(at 186.69 19.05 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6428,7 +6835,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 163.83 23.1648 0)
+			(at 190.5 23.1648 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6437,7 +6844,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 160.02 24.13 0)
+			(at 186.69 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6446,7 +6853,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 160.02 24.13 0)
+			(at 186.69 24.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6471,7 +6878,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 200.66 39.37 270)
+		(at 227.33 39.37 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6480,7 +6887,7 @@
 		(fields_autoplaced yes)
 		(uuid "739c80cb-2efc-4a93-af27-99a0af402ce7")
 		(property "Reference" "R17"
-			(at 200.66 33.02 90)
+			(at 227.33 33.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6488,7 +6895,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 200.66 35.56 90)
+			(at 227.33 35.56 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6496,7 +6903,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 200.406 40.386 90)
+			(at 227.076 40.386 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6505,7 +6912,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 200.66 39.37 0)
+			(at 227.33 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6514,7 +6921,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 200.66 39.37 0)
+			(at 227.33 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6539,34 +6946,32 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 82.55 114.3 180)
+		(at 77.47 116.84 90)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "768600e6-2c71-4830-a79b-2058b99e7004")
 		(property "Reference" "R10"
-			(at 85.09 113.0299 0)
+			(at 77.47 123.19 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
 			)
 		)
 		(property "Value" "1k5"
-			(at 85.09 115.5699 0)
+			(at 77.47 120.65 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 81.534 114.046 90)
+			(at 77.724 117.856 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6575,7 +6980,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 82.55 114.3 0)
+			(at 77.47 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6584,7 +6989,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 82.55 114.3 0)
+			(at 77.47 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6675,7 +7080,7 @@
 	)
 	(symbol
 		(lib_id "Connector:TestPoint")
-		(at 110.49 93.98 0)
+		(at 137.16 93.98 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6683,7 +7088,7 @@
 		(dnp no)
 		(uuid "7a3f9f63-6661-4f70-9554-796c4836e620")
 		(property "Reference" "TP1"
-			(at 113.03 89.4079 0)
+			(at 139.7 89.4079 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6692,7 +7097,7 @@
 			)
 		)
 		(property "Value" "TestPoint"
-			(at 113.03 91.9479 0)
+			(at 139.7 91.9479 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6701,7 +7106,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 115.57 93.98 0)
+			(at 142.24 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6710,7 +7115,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 115.57 93.98 0)
+			(at 142.24 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6719,7 +7124,7 @@
 			)
 		)
 		(property "Description" "test point"
-			(at 110.49 93.98 0)
+			(at 137.16 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6741,7 +7146,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 100.33 95.25 180)
+		(at 127 95.25 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6750,7 +7155,7 @@
 		(fields_autoplaced yes)
 		(uuid "7aedeb88-ff83-4f3a-bd4a-2de9d68a0822")
 		(property "Reference" "R11"
-			(at 102.87 93.9799 0)
+			(at 129.54 93.9799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6759,7 +7164,7 @@
 			)
 		)
 		(property "Value" "1M"
-			(at 102.87 96.5199 0)
+			(at 129.54 96.5199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6768,7 +7173,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 99.314 94.996 90)
+			(at 125.984 94.996 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6777,7 +7182,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 100.33 95.25 0)
+			(at 127 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6786,7 +7191,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 100.33 95.25 0)
+			(at 127 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6944,7 +7349,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 181.61 40.64 180)
+		(at 208.28 40.64 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6953,7 +7358,7 @@
 		(fields_autoplaced yes)
 		(uuid "89cce23e-5a70-40e1-b7aa-0fbd616bdc9c")
 		(property "Reference" "R16"
-			(at 184.15 39.3699 0)
+			(at 210.82 39.3699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6962,7 +7367,7 @@
 			)
 		)
 		(property "Value" "47k"
-			(at 184.15 41.9099 0)
+			(at 210.82 41.9099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6971,7 +7376,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 180.594 40.386 90)
+			(at 207.264 40.386 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6980,7 +7385,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 181.61 40.64 0)
+			(at 208.28 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6989,7 +7394,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 181.61 40.64 0)
+			(at 208.28 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7014,7 +7419,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 165.1 71.12 270)
+		(at 191.77 71.12 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7023,7 +7428,7 @@
 		(fields_autoplaced yes)
 		(uuid "8f4cd097-e5d4-4660-8de8-1c5ed8a12894")
 		(property "Reference" "R14"
-			(at 165.1 64.77 90)
+			(at 191.77 64.77 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7031,7 +7436,7 @@
 			)
 		)
 		(property "Value" "68k"
-			(at 165.1 67.31 90)
+			(at 191.77 67.31 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7039,7 +7444,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 164.846 72.136 90)
+			(at 191.516 72.136 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7048,7 +7453,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 165.1 71.12 0)
+			(at 191.77 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7057,7 +7462,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 165.1 71.12 0)
+			(at 191.77 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7153,7 +7558,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 130.81 109.22 0)
+		(at 157.48 109.22 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7162,7 +7567,7 @@
 		(fields_autoplaced yes)
 		(uuid "9a026d66-5787-43d1-aadc-b578e67c3121")
 		(property "Reference" "C10"
-			(at 134.62 107.9499 0)
+			(at 161.29 107.9499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7171,7 +7576,7 @@
 			)
 		)
 		(property "Value" "2.2nF"
-			(at 134.62 110.4899 0)
+			(at 161.29 110.4899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7180,7 +7585,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 131.7752 113.03 0)
+			(at 158.4452 113.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7189,7 +7594,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 130.81 109.22 0)
+			(at 157.48 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7198,7 +7603,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 130.81 109.22 0)
+			(at 157.48 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7223,7 +7628,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 153.67 71.12 270)
+		(at 180.34 71.12 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7231,7 +7636,7 @@
 		(dnp no)
 		(uuid "9e3c6581-eabd-4cea-8f93-0b06ac753de2")
 		(property "Reference" "RV7"
-			(at 154.9401 68.58 0)
+			(at 181.6101 68.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7240,7 +7645,7 @@
 			)
 		)
 		(property "Value" "250k"
-			(at 152.4001 68.58 0)
+			(at 179.0701 68.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7249,7 +7654,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 153.67 71.12 0)
+			(at 180.34 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7258,7 +7663,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 153.67 71.12 0)
+			(at 180.34 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7267,7 +7672,7 @@
 			)
 		)
 		(property "Description" "PWM Lvl"
-			(at 153.67 62.23 90)
+			(at 180.34 62.23 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7362,7 +7767,7 @@
 	)
 	(symbol
 		(lib_id "Connector:TestPoint")
-		(at 184.15 77.47 180)
+		(at 210.82 77.47 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7371,7 +7776,7 @@
 		(fields_autoplaced yes)
 		(uuid "a4d88a79-13a4-415b-9b66-d0244d2549c3")
 		(property "Reference" "TP4"
-			(at 186.69 79.5019 0)
+			(at 213.36 79.5019 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7380,7 +7785,7 @@
 			)
 		)
 		(property "Value" "TestPoint"
-			(at 186.69 82.0419 0)
+			(at 213.36 82.0419 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7389,7 +7794,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 179.07 77.47 0)
+			(at 205.74 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7398,7 +7803,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 179.07 77.47 0)
+			(at 205.74 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7407,7 +7812,7 @@
 			)
 		)
 		(property "Description" "test point"
-			(at 184.15 77.47 0)
+			(at 210.82 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7496,6 +7901,110 @@
 		)
 	)
 	(symbol
+		(lib_id "Amplifier_Operational:TL074")
+		(at 109.22 105.41 0)
+		(unit 2)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a9cb2ce3-f422-4397-ac16-407fdaf2dd99")
+		(property "Reference" "U4"
+			(at 109.22 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TL074"
+			(at 109.22 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
+			(at 107.95 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
+			(at 110.49 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
+			(at 109.22 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "3"
+			(uuid "df13b966-ae31-47c3-84b2-0192cca2d2c2")
+		)
+		(pin "2"
+			(uuid "314bb5ce-15c3-4d11-92ae-04e721f9033f")
+		)
+		(pin "4"
+			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37b")
+		)
+		(pin "7"
+			(uuid "77aaaf80-8f55-436f-b536-c603e6b43705")
+		)
+		(pin "11"
+			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff5")
+		)
+		(pin "8"
+			(uuid "66103d65-2374-465b-8e61-597635a275cf")
+		)
+		(pin "6"
+			(uuid "73f1a8dd-9d7f-490d-8380-c9a3d42b8cfb")
+		)
+		(pin "1"
+			(uuid "f8ef71cb-37ff-45b6-b2c4-6af18dafbed7")
+		)
+		(pin "13"
+			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe248e")
+		)
+		(pin "14"
+			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e715")
+		)
+		(pin "12"
+			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384b")
+		)
+		(pin "5"
+			(uuid "0bc6cf02-6f70-4bd8-88b0-42de3beea569")
+		)
+		(pin "9"
+			(uuid "9acbb5a0-ddaf-4b25-b24c-b4b97eaea58b")
+		)
+		(pin "10"
+			(uuid "4bd68a0a-02bc-4965-bd23-a853b692ceaf")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "U4")
+					(unit 2)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R_US")
 		(at 30.48 83.82 0)
 		(unit 1)
@@ -7567,7 +8076,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 220.98 26.67 270)
+		(at 243.84 26.67 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7576,7 +8085,7 @@
 		(fields_autoplaced yes)
 		(uuid "b178ede8-dd0d-484d-9616-1fb79691ec3f")
 		(property "Reference" "R20"
-			(at 220.98 20.32 90)
+			(at 243.84 20.32 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7584,7 +8093,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 220.98 22.86 90)
+			(at 243.84 22.86 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7592,7 +8101,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 220.726 27.686 90)
+			(at 243.586 27.686 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7601,7 +8110,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 220.98 26.67 0)
+			(at 243.84 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7610,7 +8119,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 220.98 26.67 0)
+			(at 243.84 26.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7635,7 +8144,7 @@
 	)
 	(symbol
 		(lib_id "Connector:TestPoint")
-		(at 125.73 86.36 90)
+		(at 152.4 86.36 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7644,7 +8153,7 @@
 		(fields_autoplaced yes)
 		(uuid "b3517dd2-19a6-4254-a9ae-4f6e9b37a748")
 		(property "Reference" "TP2"
-			(at 122.428 81.28 90)
+			(at 149.098 81.28 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7652,7 +8161,7 @@
 			)
 		)
 		(property "Value" "TestPoint"
-			(at 122.428 83.82 90)
+			(at 149.098 83.82 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7660,7 +8169,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 125.73 81.28 0)
+			(at 152.4 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7669,7 +8178,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 125.73 81.28 0)
+			(at 152.4 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7678,7 +8187,7 @@
 			)
 		)
 		(property "Description" "test point"
-			(at 125.73 86.36 0)
+			(at 152.4 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7693,6 +8202,110 @@
 			(project "VCO mki PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "TP2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Amplifier_Operational:TL074")
+		(at 77.47 107.95 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b79ce5b5-c227-46f6-99cc-09596ced13d9")
+		(property "Reference" "U4"
+			(at 77.47 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "TL074"
+			(at 77.47 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
+			(at 76.2 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
+			(at 78.74 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
+			(at 77.47 107.95 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "3"
+			(uuid "24f12c96-d1c6-4bae-ba54-4c71294c6c85")
+		)
+		(pin "2"
+			(uuid "2697b587-35f1-4109-877d-4239f8815290")
+		)
+		(pin "4"
+			(uuid "9a5212b2-4949-45d6-b0e1-a59b9f67a37c")
+		)
+		(pin "7"
+			(uuid "be82eefa-46b8-485c-8cde-feb0b3e93a71")
+		)
+		(pin "11"
+			(uuid "a220b09d-2ddf-4268-bd0e-e4cd56fa9ff6")
+		)
+		(pin "8"
+			(uuid "66103d65-2374-465b-8e61-597635a275d0")
+		)
+		(pin "6"
+			(uuid "3811c3bc-ffea-437c-ae0e-5cbed1ee3951")
+		)
+		(pin "1"
+			(uuid "ac264e28-6087-419b-9bde-26a7186a8976")
+		)
+		(pin "13"
+			(uuid "c36b129b-fcbd-45f6-b0ec-31496cbe248f")
+		)
+		(pin "14"
+			(uuid "b176c1ac-c3d4-4df9-9077-bef8e404e716")
+		)
+		(pin "12"
+			(uuid "9c3bf840-6a36-40af-bbef-0319eecb384c")
+		)
+		(pin "5"
+			(uuid "933b4c9c-0993-4992-a6a1-02a42d74cd1a")
+		)
+		(pin "9"
+			(uuid "9acbb5a0-ddaf-4b25-b24c-b4b97eaea58c")
+		)
+		(pin "10"
+			(uuid "4bd68a0a-02bc-4965-bd23-a853b692ceb0")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "U4")
 					(unit 1)
 				)
 			)
@@ -7908,7 +8521,7 @@
 	)
 	(symbol
 		(lib_id "Transistor_BJT:BC548")
-		(at 115.57 107.95 0)
+		(at 142.24 107.95 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7917,7 +8530,7 @@
 		(fields_autoplaced yes)
 		(uuid "cb8f8b25-d9bd-403b-90be-45d638c1831d")
 		(property "Reference" "Q2"
-			(at 120.65 106.6799 0)
+			(at 147.32 106.6799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7926,7 +8539,7 @@
 			)
 		)
 		(property "Value" "BC548"
-			(at 120.65 109.2199 0)
+			(at 147.32 109.2199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7935,7 +8548,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_THT:TO-92_Inline"
-			(at 120.65 109.855 0)
+			(at 147.32 109.855 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7946,7 +8559,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BC550-D.pdf"
-			(at 115.57 107.95 0)
+			(at 142.24 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7956,7 +8569,7 @@
 			)
 		)
 		(property "Description" "0.1A Ic, 30V Vce, Small Signal NPN Transistor, TO-92"
-			(at 115.57 107.95 0)
+			(at 142.24 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7984,7 +8597,7 @@
 	)
 	(symbol
 		(lib_id "Amplifier_Operational:TL074")
-		(at 233.68 67.31 0)
+		(at 247.65 67.31 0)
 		(unit 4)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7993,7 +8606,7 @@
 		(fields_autoplaced yes)
 		(uuid "d0dc4f7e-0808-42f3-8bb0-7a0e6e632468")
 		(property "Reference" "U2"
-			(at 233.68 57.15 0)
+			(at 247.65 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8001,7 +8614,7 @@
 			)
 		)
 		(property "Value" "TL074"
-			(at 233.68 59.69 0)
+			(at 247.65 59.69 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8009,7 +8622,7 @@
 			)
 		)
 		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
-			(at 232.41 64.77 0)
+			(at 246.38 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8018,7 +8631,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
-			(at 234.95 62.23 0)
+			(at 248.92 62.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8027,7 +8640,7 @@
 			)
 		)
 		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
-			(at 233.68 67.31 0)
+			(at 247.65 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8088,7 +8701,7 @@
 	)
 	(symbol
 		(lib_id "Amplifier_Operational:TL074")
-		(at 191.77 64.77 0)
+		(at 218.44 64.77 0)
 		(unit 3)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8097,7 +8710,7 @@
 		(fields_autoplaced yes)
 		(uuid "d4c88e63-bd9f-44cd-8283-689ad75cb600")
 		(property "Reference" "U2"
-			(at 191.77 54.61 0)
+			(at 218.44 54.61 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8105,7 +8718,7 @@
 			)
 		)
 		(property "Value" "TL074"
-			(at 191.77 57.15 0)
+			(at 218.44 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8113,7 +8726,7 @@
 			)
 		)
 		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
-			(at 190.5 62.23 0)
+			(at 217.17 62.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8122,7 +8735,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
-			(at 193.04 59.69 0)
+			(at 219.71 59.69 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8131,7 +8744,7 @@
 			)
 		)
 		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
-			(at 191.77 64.77 0)
+			(at 218.44 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8393,8 +9006,76 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R_US")
+		(at 93.98 107.95 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d99d1e5f-c572-4e41-9031-40814d376b85")
+		(property "Reference" "R37"
+			(at 93.98 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 93.98 104.14 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 94.234 106.934 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 93.98 107.95 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 93.98 107.95 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "4c5e8807-10ad-414a-afb1-979e303ee274")
+		)
+		(pin "1"
+			(uuid "9f016e9e-56f4-48d9-8157-69a882596c2c")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R37")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
-		(at 82.55 132.08 0)
+		(at 118.11 134.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8403,7 +9084,7 @@
 		(fields_autoplaced yes)
 		(uuid "d9dee118-bd8d-46d6-a570-70104a0b3ff0")
 		(property "Reference" "#PWR019"
-			(at 82.55 138.43 0)
+			(at 118.11 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8412,7 +9093,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 82.55 137.16 0)
+			(at 118.11 139.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8420,7 +9101,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 82.55 132.08 0)
+			(at 118.11 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8429,7 +9110,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 82.55 132.08 0)
+			(at 118.11 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8438,7 +9119,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 82.55 132.08 0)
+			(at 118.11 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8525,7 +9206,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 213.36 80.01 0)
+		(at 236.22 80.01 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8534,7 +9215,7 @@
 		(fields_autoplaced yes)
 		(uuid "dcfab24e-a10b-43d3-8dc9-79d634035fcd")
 		(property "Reference" "#PWR029"
-			(at 213.36 86.36 0)
+			(at 236.22 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8543,7 +9224,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 213.36 85.09 0)
+			(at 236.22 85.09 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8551,7 +9232,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 213.36 80.01 0)
+			(at 236.22 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8560,7 +9241,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 213.36 80.01 0)
+			(at 236.22 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8569,7 +9250,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 213.36 80.01 0)
+			(at 236.22 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8657,7 +9338,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 252.73 67.31 270)
+		(at 264.16 67.31 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8666,7 +9347,7 @@
 		(fields_autoplaced yes)
 		(uuid "e2e13412-4a09-4c57-a8fb-93bf4c93a255")
 		(property "Reference" "R21"
-			(at 252.73 60.96 90)
+			(at 264.16 60.96 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8674,7 +9355,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 252.73 63.5 90)
+			(at 264.16 63.5 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8682,7 +9363,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 252.476 68.326 90)
+			(at 263.906 68.326 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8691,7 +9372,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 252.73 67.31 0)
+			(at 264.16 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8700,7 +9381,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 252.73 67.31 0)
+			(at 264.16 67.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8793,7 +9474,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 207.01 64.77 270)
+		(at 231.14 64.77 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8802,7 +9483,7 @@
 		(fields_autoplaced yes)
 		(uuid "facdb050-a937-4ec1-81c0-55de1e6ffbd8")
 		(property "Reference" "R18"
-			(at 207.01 58.42 90)
+			(at 231.14 58.42 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8810,7 +9491,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 207.01 60.96 90)
+			(at 231.14 60.96 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8818,7 +9499,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 206.756 65.786 90)
+			(at 230.886 65.786 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8827,7 +9508,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 207.01 64.77 0)
+			(at 231.14 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8836,7 +9517,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 207.01 64.77 0)
+			(at 231.14 64.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2896,6 +2896,12 @@
 		(uuid "3f4e7280-9597-4d6e-abf4-5697e7370793")
 	)
 	(junction
+		(at 72.39 83.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "41764420-cee3-48fa-861c-32b2bab0ff4a")
+	)
+	(junction
 		(at 36.83 88.9)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2960,12 +2966,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "814bf1cb-0f24-43e1-8347-dd59c37c0dfa")
-	)
-	(junction
-		(at 72.39 82.55)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "84ddafda-8077-40fd-b1c6-7b2b7a4e3d3a")
 	)
 	(junction
 		(at 217.17 29.21)
@@ -3193,7 +3193,7 @@
 	)
 	(wire
 		(pts
-			(xy 36.83 88.9) (xy 43.18 88.9)
+			(xy 36.83 88.9) (xy 38.1 88.9)
 		)
 		(stroke
 			(width 0)
@@ -3343,13 +3343,23 @@
 	)
 	(wire
 		(pts
-			(xy 57.15 85.09) (xy 57.15 82.55)
+			(xy 52.07 85.09) (xy 52.07 83.82)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "3000fa1e-1068-496b-acaa-743383072634")
+	)
+	(wire
+		(pts
+			(xy 72.39 60.96) (xy 72.39 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "31f60f70-9045-440d-8afe-9ec60a378745")
 	)
 	(wire
 		(pts
@@ -3373,7 +3383,7 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 88.9) (xy 63.5 88.9)
+			(xy 55.88 88.9) (xy 58.42 88.9)
 		)
 		(stroke
 			(width 0)
@@ -3393,7 +3403,7 @@
 	)
 	(wire
 		(pts
-			(xy 48.26 107.95) (xy 50.8 107.95)
+			(xy 60.96 107.95) (xy 63.5 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3643,7 +3653,7 @@
 	)
 	(wire
 		(pts
-			(xy 35.56 107.95) (xy 40.64 107.95)
+			(xy 35.56 107.95) (xy 53.34 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3703,6 +3713,16 @@
 	)
 	(wire
 		(pts
+			(xy 72.39 83.82) (xy 72.39 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6799fb50-82d3-46ef-bdca-37572cc3e532")
+	)
+	(wire
+		(pts
 			(xy 176.53 100.33) (xy 179.07 100.33)
 		)
 		(stroke
@@ -3753,23 +3773,13 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 88.9) (xy 63.5 91.44)
+			(xy 58.42 88.9) (xy 58.42 91.44)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "7489f03c-e2f9-420b-a7e1-ddd96d8cc303")
-	)
-	(wire
-		(pts
-			(xy 71.12 82.55) (xy 72.39 82.55)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "75f43099-1c80-4747-8181-4a2b5d796a0c")
 	)
 	(wire
 		(pts
@@ -3823,7 +3833,7 @@
 	)
 	(wire
 		(pts
-			(xy 57.15 82.55) (xy 63.5 82.55)
+			(xy 52.07 83.82) (xy 53.34 83.82)
 		)
 		(stroke
 			(width 0)
@@ -3873,7 +3883,7 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 69.85) (xy 63.5 71.12)
+			(xy 62.23 69.85) (xy 62.23 71.12)
 		)
 		(stroke
 			(width 0)
@@ -4023,16 +4033,6 @@
 	)
 	(wire
 		(pts
-			(xy 72.39 82.55) (xy 72.39 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "996a96ed-c462-4a53-8c34-e2bed1aed997")
-	)
-	(wire
-		(pts
 			(xy 72.39 110.49) (xy 72.39 116.84)
 		)
 		(stroke
@@ -4100,6 +4100,16 @@
 			(type default)
 		)
 		(uuid "a111b246-97e1-43ca-9dfd-b8c8da83a1a1")
+	)
+	(wire
+		(pts
+			(xy 60.96 83.82) (xy 63.5 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a3cd1f07-e2b5-4228-ba61-97a8e517dad8")
 	)
 	(wire
 		(pts
@@ -4273,6 +4283,16 @@
 	)
 	(wire
 		(pts
+			(xy 71.12 83.82) (xy 72.39 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b40e3e70-fa20-489e-b19a-9eba0b57769c")
+	)
+	(wire
+		(pts
 			(xy 41.91 54.61) (xy 41.91 73.66)
 		)
 		(stroke
@@ -4403,7 +4423,7 @@
 	)
 	(wire
 		(pts
-			(xy 58.42 69.85) (xy 63.5 69.85)
+			(xy 58.42 69.85) (xy 62.23 69.85)
 		)
 		(stroke
 			(width 0)
@@ -4643,16 +4663,6 @@
 	)
 	(wire
 		(pts
-			(xy 72.39 60.96) (xy 72.39 82.55)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f36e7e88-16f3-432a-9aa3-ee9260743e69")
-	)
-	(wire
-		(pts
 			(xy 36.83 88.9) (xy 36.83 90.17)
 		)
 		(stroke
@@ -4673,7 +4683,7 @@
 	)
 	(wire
 		(pts
-			(xy 50.8 88.9) (xy 53.34 88.9)
+			(xy 45.72 88.9) (xy 48.26 88.9)
 		)
 		(stroke
 			(width 0)
@@ -4713,7 +4723,7 @@
 	)
 	(wire
 		(pts
-			(xy 58.42 107.95) (xy 72.39 107.95)
+			(xy 71.12 107.95) (xy 72.39 107.95)
 		)
 		(stroke
 			(width 0)
@@ -5613,7 +5623,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 46.99 88.9 270)
+		(at 41.91 88.9 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -5622,7 +5632,7 @@
 		(dnp no)
 		(uuid "287a1fd3-0ad4-4e71-b6bc-de5063f79b85")
 		(property "Reference" "R42"
-			(at 44.704 83.312 90)
+			(at 39.624 83.312 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5631,7 +5641,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 44.704 85.852 90)
+			(at 39.624 85.852 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5640,7 +5650,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 46.736 87.884 90)
+			(at 41.656 87.884 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5649,7 +5659,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 46.99 88.9 0)
+			(at 41.91 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5658,7 +5668,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 46.99 88.9 0)
+			(at 41.91 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6395,6 +6405,74 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:Thermistor_US")
+		(at 67.31 83.82 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3f17333f-43d2-4425-b9e6-4f573e157716")
+		(property "Reference" "TH3"
+			(at 67.31 77.47 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 67.31 80.01 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 67.31 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 67.31 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
+			(at 67.31 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "12861d75-8047-4463-b04e-eaca7f004204")
+		)
+		(pin "1"
+			(uuid "8b569f96-ee2e-4dea-bc4d-d8229d47ccab")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "TH3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:+12V")
 		(at 129.54 86.36 0)
 		(unit 1)
@@ -6596,7 +6674,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 44.45 107.95 90)
+		(at 57.15 107.95 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6605,7 +6683,7 @@
 		(fields_autoplaced yes)
 		(uuid "54227056-63ef-4bd9-81a5-a1b42b4cf8a2")
 		(property "Reference" "R7"
-			(at 44.45 101.6 90)
+			(at 57.15 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6613,7 +6691,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 44.45 104.14 90)
+			(at 57.15 104.14 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6621,7 +6699,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 44.704 106.934 90)
+			(at 57.404 106.934 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6630,7 +6708,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 44.45 107.95 0)
+			(at 57.15 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6639,7 +6717,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 44.45 107.95 0)
+			(at 57.15 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8700,7 +8778,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_Trim_US")
-		(at 57.15 88.9 90)
+		(at 52.07 88.9 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8708,7 +8786,7 @@
 		(dnp no)
 		(uuid "aad5f486-f28b-4bf3-a898-786ee2e7c8fb")
 		(property "Reference" "RV12"
-			(at 54.864 92.456 90)
+			(at 49.784 92.456 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8717,7 +8795,7 @@
 			)
 		)
 		(property "Value" "50k"
-			(at 54.864 94.996 90)
+			(at 49.784 94.996 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8726,7 +8804,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 57.15 88.9 0)
+			(at 52.07 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8735,7 +8813,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 57.15 88.9 0)
+			(at 52.07 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8744,7 +8822,7 @@
 			)
 		)
 		(property "Description" "Trim-potentiometer, US symbol"
-			(at 57.15 88.9 0)
+			(at 52.07 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8753,7 +8831,7 @@
 			)
 		)
 		(property "Function" "Centering"
-			(at 56.642 97.028 90)
+			(at 51.562 97.028 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8780,7 +8858,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 63.5 91.44 0)
+		(at 58.42 91.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8788,7 +8866,7 @@
 		(dnp no)
 		(uuid "ab4f7bcd-9c8c-40e7-9655-4524b214aa62")
 		(property "Reference" "#PWR043"
-			(at 63.5 97.79 0)
+			(at 58.42 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8797,7 +8875,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 63.5 95.25 0)
+			(at 58.42 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8805,7 +8883,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 63.5 91.44 0)
+			(at 58.42 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8814,7 +8892,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 63.5 91.44 0)
+			(at 58.42 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8823,7 +8901,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 63.5 91.44 0)
+			(at 58.42 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9082,7 +9160,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 63.5 71.12 0)
+		(at 62.23 71.12 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9090,7 +9168,7 @@
 		(dnp no)
 		(uuid "c14e6133-c287-442e-982d-a66fddf37b81")
 		(property "Reference" "#PWR01"
-			(at 63.5 77.47 0)
+			(at 62.23 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9099,7 +9177,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 63.5 74.93 0)
+			(at 62.23 74.93 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9107,7 +9185,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 63.5 71.12 0)
+			(at 62.23 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9116,7 +9194,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 63.5 71.12 0)
+			(at 62.23 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9125,7 +9203,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 63.5 71.12 0)
+			(at 62.23 71.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9778,7 +9856,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 54.61 107.95 90)
+		(at 67.31 107.95 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9787,7 +9865,7 @@
 		(fields_autoplaced yes)
 		(uuid "d6ff5a2e-6143-44eb-b840-fe7bc7c4124e")
 		(property "Reference" "TH4"
-			(at 54.61 101.6 90)
+			(at 67.31 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9795,7 +9873,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 54.61 104.14 90)
+			(at 67.31 104.14 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9803,7 +9881,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 54.61 107.95 0)
+			(at 67.31 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9812,7 +9890,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 54.61 107.95 0)
+			(at 67.31 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9821,7 +9899,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 54.61 107.95 0)
+			(at 67.31 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10317,7 +10395,8 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 67.31 82.55 270)
+		(at 57.15 83.82 270)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -10325,7 +10404,7 @@
 		(dnp no)
 		(uuid "eec8db87-a26f-416a-a556-37a30194f425")
 		(property "Reference" "R43"
-			(at 65.024 88.138 90)
+			(at 54.864 78.232 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10334,7 +10413,7 @@
 			)
 		)
 		(property "Value" "1M"
-			(at 66.04 85.852 90)
+			(at 55.88 80.518 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10343,7 +10422,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 67.056 83.566 90)
+			(at 56.896 82.804 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10352,7 +10431,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 67.31 82.55 0)
+			(at 57.15 83.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10361,7 +10440,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 67.31 82.55 0)
+			(at 57.15 83.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2860,10 +2860,10 @@
 		)
 	)
 	(junction
-		(at 67.31 110.49)
+		(at 72.39 107.95)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "08cc19aa-2d15-4bb6-9dbb-7656ab235d5b")
+		(uuid "0191a663-0bad-41ec-8b63-3340d74a6d24")
 	)
 	(junction
 		(at 193.04 24.13)
@@ -2872,31 +2872,25 @@
 		(uuid "08f16d58-ed15-4500-a51f-d34b0ae83f98")
 	)
 	(junction
-		(at 63.5 110.49)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "104cf8d2-0ad0-4638-9e97-12510bca5ef0")
-	)
-	(junction
-		(at 130.81 100.33)
+		(at 133.35 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "23d18312-e5fd-4043-94fe-4ae1dafac028")
 	)
 	(junction
-		(at 41.91 73.66)
+		(at 52.07 73.66)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "2f088860-0d76-4f91-95f8-6a88de66696d")
 	)
 	(junction
-		(at 137.16 100.33)
+		(at 139.7 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "31e0807b-f998-4f11-9032-ae7bd302d351")
 	)
 	(junction
-		(at 100.33 107.95)
+		(at 102.87 107.95)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "35772588-b310-402d-95d1-bb62a12f9b7d")
@@ -2908,10 +2902,10 @@
 		(uuid "3f4e7280-9597-4d6e-abf4-5697e7370793")
 	)
 	(junction
-		(at 63.5 107.95)
+		(at 36.83 88.9)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "3fac9c83-7fa4-4206-9ef7-37fe4d3c474f")
+		(uuid "45c76194-b73a-4635-9cf9-587091a3a154")
 	)
 	(junction
 		(at 180.34 24.13)
@@ -2920,10 +2914,34 @@
 		(uuid "5118ec97-292c-4e63-b0c1-0807cda69d81")
 	)
 	(junction
+		(at 72.39 73.66)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "52e56aaa-83b4-4f65-90dc-4bb9b82232f1")
+	)
+	(junction
+		(at 72.39 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "54ae324a-03e3-47ea-8663-dba1319b08a5")
+	)
+	(junction
+		(at 36.83 58.42)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "61b505ea-fdcb-4c3c-ab73-87f92e3e6e8e")
+	)
+	(junction
 		(at 203.2 24.13)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "64b2a538-f8aa-40c9-b5a7-dd9c9c378593")
+	)
+	(junction
+		(at 72.39 110.49)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6c673bc1-7633-4acd-b30f-bfa356b79327")
 	)
 	(junction
 		(at 157.48 86.36)
@@ -2938,19 +2956,19 @@
 		(uuid "814bf1cb-0f24-43e1-8347-dd59c37c0dfa")
 	)
 	(junction
+		(at 72.39 82.55)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84ddafda-8077-40fd-b1c6-7b2b7a4e3d3a")
+	)
+	(junction
 		(at 217.17 29.21)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "87560534-6723-4cfc-b5e1-e63f9ec9f5a5")
 	)
 	(junction
-		(at 63.5 73.66)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "999cab1d-6ec4-4bf1-818d-422424e7a463")
-	)
-	(junction
-		(at 87.63 107.95)
+		(at 92.71 107.95)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a4fd3de1-7483-40c8-a4a2-a59502200f06")
@@ -2962,16 +2980,16 @@
 		(uuid "abcdb0d0-94b4-4cc5-a632-23de5d93fa17")
 	)
 	(junction
-		(at 63.5 133.35)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "aec66786-dd86-4d04-a45d-d2970fb61bc0")
-	)
-	(junction
 		(at 257.81 67.31)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c4ecfdce-6512-4d84-b8fc-1069a8acd56f")
+	)
+	(junction
+		(at 72.39 116.84)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c993f72d-f12c-43f0-a475-b9af82e8a6af")
 	)
 	(junction
 		(at 173.99 71.12)
@@ -2986,26 +3004,20 @@
 		(uuid "cd45eacf-dd4b-447d-915a-ff112a50087e")
 	)
 	(junction
-		(at 26.67 78.74)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "d05b33e3-2cd2-478b-8ba6-989f7a417815")
-	)
-	(junction
 		(at 199.39 67.31)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d422d8f8-e13e-4112-aab9-1d5701fb4960")
 	)
 	(junction
-		(at 118.11 118.11)
+		(at 120.65 118.11)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "dad030f8-933a-42b6-ab7a-67bf371c7c20")
 	)
 	(wire
 		(pts
-			(xy 87.63 107.95) (xy 87.63 116.84)
+			(xy 92.71 107.95) (xy 92.71 116.84)
 		)
 		(stroke
 			(width 0)
@@ -3015,7 +3027,17 @@
 	)
 	(wire
 		(pts
-			(xy 46.99 77.47) (xy 41.91 77.47)
+			(xy 22.86 59.69) (xy 22.86 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "014d2cd4-f645-4968-96db-fec542f9b3f7")
+	)
+	(wire
+		(pts
+			(xy 57.15 77.47) (xy 52.07 77.47)
 		)
 		(stroke
 			(width 0)
@@ -3035,16 +3057,6 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 110.49) (xy 67.31 110.49)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0786a5b9-d709-4913-868b-450ddc77b977")
-	)
-	(wire
-		(pts
 			(xy 199.39 71.12) (xy 199.39 74.93)
 		)
 		(stroke
@@ -3055,13 +3067,23 @@
 	)
 	(wire
 		(pts
-			(xy 41.91 73.66) (xy 43.18 73.66)
+			(xy 52.07 73.66) (xy 53.34 73.66)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "081cea57-d0c1-46d6-a3ad-e352dcb2e082")
+	)
+	(wire
+		(pts
+			(xy 27.94 48.26) (xy 46.99 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "084e68fa-bd0e-4210-b410-bddf020dbe69")
 	)
 	(wire
 		(pts
@@ -3125,7 +3147,7 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 107.95) (xy 101.6 107.95)
+			(xy 102.87 107.95) (xy 104.14 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3135,7 +3157,7 @@
 	)
 	(wire
 		(pts
-			(xy 69.85 105.41) (xy 69.85 88.9)
+			(xy 74.93 105.41) (xy 74.93 88.9)
 		)
 		(stroke
 			(width 0)
@@ -3145,7 +3167,7 @@
 	)
 	(wire
 		(pts
-			(xy 127 99.06) (xy 127 100.33)
+			(xy 129.54 99.06) (xy 129.54 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3175,13 +3197,33 @@
 	)
 	(wire
 		(pts
-			(xy 123.19 109.22) (xy 123.19 127)
+			(xy 36.83 88.9) (xy 43.18 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1ae4f7cf-7cda-44e2-a88d-b67229b9f7b0")
+	)
+	(wire
+		(pts
+			(xy 125.73 109.22) (xy 125.73 127)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "1df88b2f-fbb8-4936-8fd8-111afad70543")
+	)
+	(wire
+		(pts
+			(xy 36.83 67.31) (xy 36.83 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2312db26-4982-4b0d-bfa0-db80c525caf7")
 	)
 	(wire
 		(pts
@@ -3195,7 +3237,7 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 73.66) (xy 63.5 39.37)
+			(xy 72.39 73.66) (xy 72.39 48.26)
 		)
 		(stroke
 			(width 0)
@@ -3265,6 +3307,16 @@
 	)
 	(wire
 		(pts
+			(xy 22.86 77.47) (xy 22.86 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2f10cb6f-3e11-46fc-a6c4-da2f33e8af28")
+	)
+	(wire
+		(pts
 			(xy 157.48 100.33) (xy 161.29 100.33)
 		)
 		(stroke
@@ -3272,6 +3324,16 @@
 			(type default)
 		)
 		(uuid "2fa9d208-97af-4c94-b741-c8f286984c08")
+	)
+	(wire
+		(pts
+			(xy 57.15 85.09) (xy 57.15 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3000fa1e-1068-496b-acaa-743383072634")
 	)
 	(wire
 		(pts
@@ -3285,16 +3347,6 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 83.82) (xy 30.48 78.74)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "33057753-0412-4ec2-abfb-77f31ce66ed7")
-	)
-	(wire
-		(pts
 			(xy 173.99 77.47) (xy 173.99 71.12)
 		)
 		(stroke
@@ -3305,13 +3357,23 @@
 	)
 	(wire
 		(pts
-			(xy 81.28 116.84) (xy 87.63 116.84)
+			(xy 91.44 116.84) (xy 92.71 116.84)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "34d33e19-9b48-44ac-997a-e2c3932e15af")
+	)
+	(wire
+		(pts
+			(xy 60.96 88.9) (xy 63.5 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3604d466-ca7d-4b93-9805-4d156f03c108")
 	)
 	(wire
 		(pts
@@ -3325,7 +3387,7 @@
 	)
 	(wire
 		(pts
-			(xy 38.1 107.95) (xy 40.64 107.95)
+			(xy 48.26 107.95) (xy 50.8 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3335,7 +3397,7 @@
 	)
 	(wire
 		(pts
-			(xy 137.16 93.98) (xy 137.16 100.33)
+			(xy 139.7 93.98) (xy 139.7 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3345,7 +3407,17 @@
 	)
 	(wire
 		(pts
-			(xy 85.09 107.95) (xy 87.63 107.95)
+			(xy 22.86 88.9) (xy 36.83 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a3df48e-3bf4-4368-bb94-212bef94ab68")
+	)
+	(wire
+		(pts
+			(xy 91.44 107.95) (xy 92.71 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3365,7 +3437,7 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 88.9) (xy 104.14 88.9)
+			(xy 101.6 88.9) (xy 106.68 88.9)
 		)
 		(stroke
 			(width 0)
@@ -3385,27 +3457,7 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 78.74) (xy 26.67 80.01)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3e124dc0-dcbe-4427-b544-14de8f108428")
-	)
-	(wire
-		(pts
-			(xy 25.4 39.37) (xy 25.4 46.99)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3e932d86-9da5-4e58-854d-58bc67321fe3")
-	)
-	(wire
-		(pts
-			(xy 60.96 152.4) (xy 63.5 152.4)
+			(xy 71.12 140.97) (xy 72.39 140.97)
 		)
 		(stroke
 			(width 0)
@@ -3445,33 +3497,33 @@
 	)
 	(wire
 		(pts
-			(xy 25.4 29.21) (xy 25.4 31.75)
+			(xy 36.83 87.63) (xy 36.83 88.9)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "4596a976-d93d-46ff-a55c-13bf19d1afa8")
+		(uuid "440f254b-68fe-4435-9da1-2c460f50312d")
 	)
 	(wire
 		(pts
-			(xy 144.78 102.87) (xy 144.78 100.33)
+			(xy 72.39 116.84) (xy 72.39 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "488199e3-bbac-477d-b2a8-9bb7344fb41e")
+	)
+	(wire
+		(pts
+			(xy 147.32 102.87) (xy 147.32 100.33)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "48a7a74a-e082-42b3-8f43-383e5dd4b26d")
-	)
-	(wire
-		(pts
-			(xy 17.78 21.59) (xy 17.78 29.21)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4d5c347d-32ab-43cc-8e63-d6010145969b")
 	)
 	(wire
 		(pts
@@ -3485,13 +3537,33 @@
 	)
 	(wire
 		(pts
-			(xy 67.31 116.84) (xy 67.31 110.49)
+			(xy 36.83 58.42) (xy 36.83 59.69)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "5146822f-690b-4792-aa45-36346832661d")
+		(uuid "4d948125-a8d8-4c2b-a2af-f9a62bd23c0c")
+	)
+	(wire
+		(pts
+			(xy 72.39 116.84) (xy 83.82 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4fa2e053-61e6-4c4e-93e0-04f00a218eb1")
+	)
+	(wire
+		(pts
+			(xy 92.71 107.95) (xy 93.98 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "506e8a11-ed94-426d-902f-d23125179ebe")
 	)
 	(wire
 		(pts
@@ -3515,6 +3587,16 @@
 	)
 	(wire
 		(pts
+			(xy 72.39 110.49) (xy 76.2 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "549a2308-6014-4394-aabc-b1571b4f6841")
+	)
+	(wire
+		(pts
 			(xy 157.48 113.03) (xy 157.48 115.57)
 		)
 		(stroke
@@ -3525,13 +3607,23 @@
 	)
 	(wire
 		(pts
-			(xy 25.4 107.95) (xy 30.48 107.95)
+			(xy 35.56 107.95) (xy 40.64 107.95)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "5c948a34-0c2c-464e-a01b-65ad140c4ef2")
+	)
+	(wire
+		(pts
+			(xy 40.64 73.66) (xy 43.18 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d7497c4-f1c6-43da-b8c4-a131856e840e")
 	)
 	(wire
 		(pts
@@ -3545,16 +3637,6 @@
 	)
 	(wire
 		(pts
-			(xy 33.02 35.56) (xy 33.02 39.37)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "61870277-3976-402b-8ba3-a7ccca1836f2")
-	)
-	(wire
-		(pts
 			(xy 162.56 21.59) (xy 157.48 21.59)
 		)
 		(stroke
@@ -3565,23 +3647,23 @@
 	)
 	(wire
 		(pts
-			(xy 36.83 127) (xy 36.83 129.54)
+			(xy 36.83 77.47) (xy 36.83 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6434a17c-82c1-46f5-b0f3-ab140d6d4474")
+	)
+	(wire
+		(pts
+			(xy 46.99 115.57) (xy 46.99 118.11)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "662caa03-27ad-4271-9a75-ad5e14f81e2b")
-	)
-	(wire
-		(pts
-			(xy 33.02 39.37) (xy 36.83 39.37)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "67dff529-5b28-4e38-b28a-3eae13b5ce2f")
 	)
 	(wire
 		(pts
@@ -3595,16 +3677,6 @@
 	)
 	(wire
 		(pts
-			(xy 15.24 64.77) (xy 15.24 67.31)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6cd0fcf3-7f48-41e4-8b80-557b23906756")
-	)
-	(wire
-		(pts
 			(xy 180.34 74.93) (xy 180.34 77.47)
 		)
 		(stroke
@@ -3615,7 +3687,7 @@
 	)
 	(wire
 		(pts
-			(xy 97.79 107.95) (xy 100.33 107.95)
+			(xy 101.6 107.95) (xy 102.87 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3625,13 +3697,23 @@
 	)
 	(wire
 		(pts
-			(xy 30.48 73.66) (xy 33.02 73.66)
+			(xy 63.5 88.9) (xy 63.5 91.44)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "7552adeb-7d9f-4963-b611-e25f39e46b8e")
+		(uuid "7489f03c-e2f9-420b-a7e1-ddd96d8cc303")
+	)
+	(wire
+		(pts
+			(xy 71.12 82.55) (xy 72.39 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "75f43099-1c80-4747-8181-4a2b5d796a0c")
 	)
 	(wire
 		(pts
@@ -3645,7 +3727,7 @@
 	)
 	(wire
 		(pts
-			(xy 36.83 137.16) (xy 36.83 139.7)
+			(xy 46.99 125.73) (xy 46.99 128.27)
 		)
 		(stroke
 			(width 0)
@@ -3665,7 +3747,7 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 100.33) (xy 130.81 104.14)
+			(xy 133.35 100.33) (xy 133.35 104.14)
 		)
 		(stroke
 			(width 0)
@@ -3675,7 +3757,7 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 73.66) (xy 63.5 73.66)
+			(xy 71.12 73.66) (xy 72.39 73.66)
 		)
 		(stroke
 			(width 0)
@@ -3705,6 +3787,16 @@
 	)
 	(wire
 		(pts
+			(xy 57.15 82.55) (xy 63.5 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f8921fd-2e0a-4374-8cc5-c09f00e0501b")
+	)
+	(wire
+		(pts
 			(xy 160.02 26.67) (xy 160.02 30.48)
 		)
 		(stroke
@@ -3725,7 +3817,7 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 105.41) (xy 116.84 105.41)
+			(xy 120.65 105.41) (xy 119.38 105.41)
 		)
 		(stroke
 			(width 0)
@@ -3735,7 +3827,7 @@
 	)
 	(wire
 		(pts
-			(xy 127 86.36) (xy 127 91.44)
+			(xy 129.54 86.36) (xy 129.54 91.44)
 		)
 		(stroke
 			(width 0)
@@ -3745,7 +3837,17 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 130.81) (xy 118.11 133.35)
+			(xy 72.39 73.66) (xy 72.39 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "82df5172-2857-4796-8f45-3de215f2ee74")
+	)
+	(wire
+		(pts
+			(xy 120.65 130.81) (xy 120.65 133.35)
 		)
 		(stroke
 			(width 0)
@@ -3765,13 +3867,23 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 133.35) (xy 63.5 152.4)
+			(xy 72.39 121.92) (xy 72.39 140.97)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "8cc31db5-dd29-4540-8a24-285256f6099b")
+	)
+	(wire
+		(pts
+			(xy 26.67 73.66) (xy 27.94 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8cd2d780-7811-40d2-8fac-0858a7a74a4c")
 	)
 	(wire
 		(pts
@@ -3805,7 +3917,17 @@
 	)
 	(wire
 		(pts
-			(xy 40.64 73.66) (xy 41.91 73.66)
+			(xy 74.93 105.41) (xy 76.2 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "946a8b10-0d43-4fc1-abc9-cb9bf0879ab9")
+	)
+	(wire
+		(pts
+			(xy 50.8 73.66) (xy 52.07 73.66)
 		)
 		(stroke
 			(width 0)
@@ -3815,7 +3937,7 @@
 	)
 	(wire
 		(pts
-			(xy 100.33 118.11) (xy 100.33 107.95)
+			(xy 102.87 118.11) (xy 102.87 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3825,7 +3947,7 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 100.33) (xy 137.16 100.33)
+			(xy 133.35 100.33) (xy 139.7 100.33)
 		)
 		(stroke
 			(width 0)
@@ -3845,7 +3967,17 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 110.49) (xy 63.5 133.35)
+			(xy 72.39 82.55) (xy 72.39 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "996a96ed-c462-4a53-8c34-e2bed1aed997")
+	)
+	(wire
+		(pts
+			(xy 72.39 110.49) (xy 72.39 116.84)
 		)
 		(stroke
 			(width 0)
@@ -3875,7 +4007,7 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 107.95) (xy 63.5 110.49)
+			(xy 72.39 107.95) (xy 72.39 110.49)
 		)
 		(stroke
 			(width 0)
@@ -3895,17 +4027,7 @@
 	)
 	(wire
 		(pts
-			(xy 67.31 116.84) (xy 73.66 116.84)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "9ce73ca3-f476-450f-be98-841a6b45f449")
-	)
-	(wire
-		(pts
-			(xy 137.16 100.33) (xy 137.16 107.95)
+			(xy 139.7 100.33) (xy 139.7 107.95)
 		)
 		(stroke
 			(width 0)
@@ -3915,13 +4037,13 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 78.74) (xy 30.48 78.74)
+			(xy 22.86 87.63) (xy 22.86 88.9)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "9e9687b5-780d-4d31-96c0-752649d60429")
+		(uuid "a111b246-97e1-43ca-9dfd-b8c8da83a1a1")
 	)
 	(wire
 		(pts
@@ -3935,7 +4057,7 @@
 	)
 	(wire
 		(pts
-			(xy 44.45 39.37) (xy 46.99 39.37)
+			(xy 54.61 48.26) (xy 57.15 48.26)
 		)
 		(stroke
 			(width 0)
@@ -3945,17 +4067,7 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 64.77) (xy 26.67 69.85)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a8618718-a11b-4288-91cb-b896dda71072")
-	)
-	(wire
-		(pts
-			(xy 36.83 156.21) (xy 36.83 158.75)
+			(xy 46.99 144.78) (xy 46.99 147.32)
 		)
 		(stroke
 			(width 0)
@@ -3975,27 +4087,7 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 64.77) (xy 15.24 64.77)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "aa33773f-fbd9-4279-9c1a-52295fbce526")
-	)
-	(wire
-		(pts
-			(xy 29.21 35.56) (xy 33.02 35.56)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ab263ed0-502d-4085-b127-aa1b42b5a221")
-	)
-	(wire
-		(pts
-			(xy 130.81 100.33) (xy 127 100.33)
+			(xy 133.35 100.33) (xy 129.54 100.33)
 		)
 		(stroke
 			(width 0)
@@ -4005,7 +4097,7 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 140.97) (xy 118.11 143.51)
+			(xy 120.65 140.97) (xy 120.65 143.51)
 		)
 		(stroke
 			(width 0)
@@ -4015,7 +4107,7 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 133.35) (xy 63.5 133.35)
+			(xy 71.12 121.92) (xy 72.39 121.92)
 		)
 		(stroke
 			(width 0)
@@ -4025,7 +4117,7 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 118.11) (xy 118.11 123.19)
+			(xy 120.65 118.11) (xy 120.65 123.19)
 		)
 		(stroke
 			(width 0)
@@ -4035,7 +4127,7 @@
 	)
 	(wire
 		(pts
-			(xy 50.8 73.66) (xy 53.34 73.66)
+			(xy 60.96 73.66) (xy 63.5 73.66)
 		)
 		(stroke
 			(width 0)
@@ -4045,7 +4137,7 @@
 	)
 	(wire
 		(pts
-			(xy 152.4 86.36) (xy 157.48 86.36)
+			(xy 154.94 86.36) (xy 157.48 86.36)
 		)
 		(stroke
 			(width 0)
@@ -4065,7 +4157,7 @@
 	)
 	(wire
 		(pts
-			(xy 69.85 88.9) (xy 76.2 88.9)
+			(xy 74.93 88.9) (xy 78.74 88.9)
 		)
 		(stroke
 			(width 0)
@@ -4075,13 +4167,23 @@
 	)
 	(wire
 		(pts
-			(xy 41.91 77.47) (xy 41.91 73.66)
+			(xy 52.07 77.47) (xy 52.07 73.66)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "b0eabf79-a108-4076-8c06-16e7a07c776d")
+	)
+	(wire
+		(pts
+			(xy 36.83 57.15) (xy 36.83 58.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2a9eb9c-7109-43cf-add0-464a8bb537ee")
 	)
 	(wire
 		(pts
@@ -4095,7 +4197,7 @@
 	)
 	(wire
 		(pts
-			(xy 36.83 146.05) (xy 36.83 148.59)
+			(xy 46.99 134.62) (xy 46.99 137.16)
 		)
 		(stroke
 			(width 0)
@@ -4115,7 +4217,7 @@
 	)
 	(wire
 		(pts
-			(xy 115.57 118.11) (xy 118.11 118.11)
+			(xy 118.11 118.11) (xy 120.65 118.11)
 		)
 		(stroke
 			(width 0)
@@ -4135,7 +4237,7 @@
 	)
 	(wire
 		(pts
-			(xy 107.95 118.11) (xy 100.33 118.11)
+			(xy 110.49 118.11) (xy 102.87 118.11)
 		)
 		(stroke
 			(width 0)
@@ -4145,7 +4247,7 @@
 	)
 	(wire
 		(pts
-			(xy 123.19 127) (xy 121.92 127)
+			(xy 125.73 127) (xy 124.46 127)
 		)
 		(stroke
 			(width 0)
@@ -4175,7 +4277,7 @@
 	)
 	(wire
 		(pts
-			(xy 54.61 39.37) (xy 63.5 39.37)
+			(xy 64.77 48.26) (xy 72.39 48.26)
 		)
 		(stroke
 			(width 0)
@@ -4185,7 +4287,7 @@
 	)
 	(wire
 		(pts
-			(xy 144.78 100.33) (xy 157.48 100.33)
+			(xy 147.32 100.33) (xy 157.48 100.33)
 		)
 		(stroke
 			(width 0)
@@ -4195,17 +4297,17 @@
 	)
 	(wire
 		(pts
-			(xy 17.78 46.99) (xy 17.78 49.53)
+			(xy 22.86 58.42) (xy 36.83 58.42)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c783f383-d7b8-45fd-8740-48c0236f76a0")
+		(uuid "c7e09d5f-cfdb-4095-89e1-41773638cb6c")
 	)
 	(wire
 		(pts
-			(xy 40.64 152.4) (xy 43.18 152.4)
+			(xy 50.8 140.97) (xy 53.34 140.97)
 		)
 		(stroke
 			(width 0)
@@ -4225,7 +4327,7 @@
 	)
 	(wire
 		(pts
-			(xy 144.78 113.03) (xy 144.78 115.57)
+			(xy 147.32 113.03) (xy 147.32 115.57)
 		)
 		(stroke
 			(width 0)
@@ -4235,7 +4337,17 @@
 	)
 	(wire
 		(pts
-			(xy 101.6 102.87) (xy 99.06 102.87)
+			(xy 27.94 73.66) (xy 27.94 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cf7d19c3-6026-48a8-a02f-8cb0c38ae458")
+	)
+	(wire
+		(pts
+			(xy 104.14 102.87) (xy 101.6 102.87)
 		)
 		(stroke
 			(width 0)
@@ -4245,17 +4357,7 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 87.63) (xy 26.67 90.17)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d1a066cd-8cf7-4d28-acb0-cc8bae66383b")
-	)
-	(wire
-		(pts
-			(xy 40.64 133.35) (xy 43.18 133.35)
+			(xy 50.8 121.92) (xy 53.34 121.92)
 		)
 		(stroke
 			(width 0)
@@ -4265,17 +4367,7 @@
 	)
 	(wire
 		(pts
-			(xy 87.63 107.95) (xy 90.17 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d7142958-03f2-4b49-8521-cc44403221dc")
-	)
-	(wire
-		(pts
-			(xy 25.4 146.05) (xy 36.83 146.05)
+			(xy 35.56 134.62) (xy 46.99 134.62)
 		)
 		(stroke
 			(width 0)
@@ -4285,7 +4377,7 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 105.41) (xy 118.11 118.11)
+			(xy 120.65 105.41) (xy 120.65 118.11)
 		)
 		(stroke
 			(width 0)
@@ -4325,16 +4417,6 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 73.66) (xy 63.5 107.95)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e259bd3c-427e-4b9e-88ce-c21543faf30b")
-	)
-	(wire
-		(pts
 			(xy 157.48 21.59) (xy 157.48 86.36)
 		)
 		(stroke
@@ -4365,7 +4447,7 @@
 	)
 	(wire
 		(pts
-			(xy 130.81 114.3) (xy 130.81 115.57)
+			(xy 133.35 114.3) (xy 133.35 115.57)
 		)
 		(stroke
 			(width 0)
@@ -4375,7 +4457,7 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 102.87) (xy 99.06 88.9)
+			(xy 101.6 102.87) (xy 101.6 88.9)
 		)
 		(stroke
 			(width 0)
@@ -4385,7 +4467,17 @@
 	)
 	(wire
 		(pts
-			(xy 50.8 152.4) (xy 53.34 152.4)
+			(xy 22.86 67.31) (xy 22.86 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e77b08eb-854d-48d1-972f-47ccaeccfce0")
+	)
+	(wire
+		(pts
+			(xy 60.96 140.97) (xy 63.5 140.97)
 		)
 		(stroke
 			(width 0)
@@ -4395,33 +4487,33 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 77.47) (xy 26.67 78.74)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "eb960083-beb3-42ed-b675-31625e75cdcb")
-	)
-	(wire
-		(pts
-			(xy 67.31 110.49) (xy 69.85 110.49)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ec6517a2-8a39-48c1-8ebf-17131ddef4b1")
-	)
-	(wire
-		(pts
-			(xy 50.8 133.35) (xy 53.34 133.35)
+			(xy 60.96 121.92) (xy 63.5 121.92)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "f12e0476-ca12-4439-bbba-9226f312b951")
+	)
+	(wire
+		(pts
+			(xy 36.83 88.9) (xy 36.83 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f50aa770-c62b-47b1-b862-2f373b339fa9")
+	)
+	(wire
+		(pts
+			(xy 50.8 88.9) (xy 53.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f9170384-ea90-453f-ab41-9865c27e6d32")
 	)
 	(wire
 		(pts
@@ -4435,7 +4527,7 @@
 	)
 	(wire
 		(pts
-			(xy 25.4 127) (xy 36.83 127)
+			(xy 35.56 115.57) (xy 46.99 115.57)
 		)
 		(stroke
 			(width 0)
@@ -4455,7 +4547,7 @@
 	)
 	(wire
 		(pts
-			(xy 48.26 107.95) (xy 63.5 107.95)
+			(xy 58.42 107.95) (xy 72.39 107.95)
 		)
 		(stroke
 			(width 0)
@@ -4474,18 +4566,6 @@
 			(type none)
 		)
 		(uuid 1ff8bbd6-1d59-42b5-8ac5-baac6cc7c35d)
-	)
-	(circle
-		(center 21.59 44.45)
-		(radius 5.6796)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(fill
-			(type none)
-		)
-		(uuid 39165d86-ba24-4f26-a39b-a36c41f539fb)
 	)
 	(circle
 		(center 179.832 69.342)
@@ -4531,7 +4611,7 @@
 	)
 	(text "RD09 pots pinout:\nwhen viewing the pot from above and the pins are on the south side,\n1 = right = fully CW\n2 = middle\n3 = left = fully CCW"
 		(exclude_from_sim no)
-		(at 26.67 19.304 0)
+		(at 53.594 20.32 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4542,7 +4622,7 @@
 	)
 	(hierarchical_label "Exp FM In 1"
 		(shape input)
-		(at 25.4 127 180)
+		(at 35.56 115.57 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4590,7 +4670,7 @@
 	)
 	(hierarchical_label "V{slash}Oct In"
 		(shape input)
-		(at 25.4 107.95 180)
+		(at 35.56 107.95 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4614,7 +4694,7 @@
 	)
 	(hierarchical_label "Exp FM In 2"
 		(shape input)
-		(at 25.4 146.05 180)
+		(at 35.56 134.62 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4626,15 +4706,15 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_Trim_US")
-		(at 46.99 73.66 270)
+		(at 57.15 73.66 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(uuid "01e8a046-fa9f-4d17-9a61-8e7d9ee2f54d")
-		(property "Reference" "R5"
-			(at 48.26 68.58 0)
+		(property "Reference" "RV11"
+			(at 57.15 67.31 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4642,7 +4722,7 @@
 			)
 		)
 		(property "Value" "1M"
-			(at 45.72 68.58 0)
+			(at 57.15 69.85 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4650,7 +4730,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 46.99 73.66 0)
+			(at 57.15 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4659,7 +4739,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 46.99 73.66 0)
+			(at 57.15 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4668,7 +4748,7 @@
 			)
 		)
 		(property "Description" "Trim-potentiometer, US symbol"
-			(at 46.99 73.66 0)
+			(at 57.15 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4688,7 +4768,7 @@
 		(instances
 			(project "VCO mki PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
-					(reference "R5")
+					(reference "RV11")
 					(unit 1)
 				)
 			)
@@ -4762,7 +4842,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 144.78 115.57 0)
+		(at 147.32 115.57 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4771,7 +4851,7 @@
 		(fields_autoplaced yes)
 		(uuid "0ca7b7ef-9640-4f9c-b711-82537a7cde8e")
 		(property "Reference" "#PWR022"
-			(at 144.78 121.92 0)
+			(at 147.32 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4780,7 +4860,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 144.78 120.65 0)
+			(at 147.32 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4788,7 +4868,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 144.78 115.57 0)
+			(at 147.32 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4797,7 +4877,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 144.78 115.57 0)
+			(at 147.32 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4806,7 +4886,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 144.78 115.57 0)
+			(at 147.32 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4965,7 +5045,7 @@
 	)
 	(symbol
 		(lib_id "power:-12V")
-		(at 130.81 115.57 180)
+		(at 133.35 115.57 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4973,7 +5053,7 @@
 		(dnp no)
 		(uuid "1566cf2a-5fd2-49eb-98d6-b14774fd127a")
 		(property "Reference" "#PWR021"
-			(at 130.81 111.76 0)
+			(at 133.35 111.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4982,7 +5062,7 @@
 			)
 		)
 		(property "Value" "-12V"
-			(at 130.81 120.65 0)
+			(at 133.35 120.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4990,7 +5070,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 130.81 115.57 0)
+			(at 133.35 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4999,7 +5079,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 130.81 115.57 0)
+			(at 133.35 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5008,7 +5088,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 130.81 115.57 0)
+			(at 133.35 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5030,7 +5110,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 46.99 133.35 90)
+		(at 57.15 121.92 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5039,7 +5119,7 @@
 		(fields_autoplaced yes)
 		(uuid "15985414-f8f9-4693-b750-b9d3781c8893")
 		(property "Reference" "R8"
-			(at 46.99 127 90)
+			(at 57.15 115.57 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5047,7 +5127,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 46.99 129.54 90)
+			(at 57.15 118.11 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5055,7 +5135,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 47.244 132.334 90)
+			(at 57.404 120.904 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5064,7 +5144,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 46.99 133.35 0)
+			(at 57.15 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5073,7 +5153,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 46.99 133.35 0)
+			(at 57.15 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5334,7 +5414,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 76.2 88.9 0)
+		(at 78.74 88.9 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5343,7 +5423,7 @@
 		(fields_autoplaced yes)
 		(uuid "22bbb18e-5ee8-4a3a-81b9-79d7cfe6f704")
 		(property "Reference" "#PWR041"
-			(at 76.2 95.25 0)
+			(at 78.74 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5352,7 +5432,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 76.2 93.98 0)
+			(at 78.74 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5360,7 +5440,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 76.2 88.9 0)
+			(at 78.74 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5369,7 +5449,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 76.2 88.9 0)
+			(at 78.74 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5378,7 +5458,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 76.2 88.9 0)
+			(at 78.74 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5393,6 +5473,76 @@
 			(project "DMH_VCO_40106_PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "#PWR041")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
+		(at 46.99 88.9 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "287a1fd3-0ad4-4e71-b6bc-de5063f79b85")
+		(property "Reference" "R42"
+			(at 44.704 83.312 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100k"
+			(at 44.704 85.852 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 46.736 87.884 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 46.99 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 46.99 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "5443cc47-8998-40de-a2e6-06d31f73527a")
+		)
+		(pin "1"
+			(uuid "4a56f63f-5abb-4588-9b74-6f2d2a8b64f6")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R42")
 					(unit 1)
 				)
 			)
@@ -5764,7 +5914,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 36.83 73.66 90)
+		(at 46.99 73.66 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5773,15 +5923,15 @@
 		(fields_autoplaced yes)
 		(uuid "37d7652a-b7d0-40b9-848a-d1215cde57fa")
 		(property "Reference" "R39"
-			(at 36.83 67.31 90)
+			(at 46.99 67.31 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 			)
 		)
-		(property "Value" "500k"
-			(at 36.83 69.85 90)
+		(property "Value" "300k"
+			(at 46.99 69.85 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5789,7 +5939,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 37.084 72.644 90)
+			(at 47.244 72.644 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5798,7 +5948,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 36.83 73.66 0)
+			(at 46.99 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5807,7 +5957,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 36.83 73.66 0)
+			(at 46.99 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5898,7 +6048,7 @@
 	)
 	(symbol
 		(lib_id "Transistor_BJT:BC558")
-		(at 128.27 109.22 0)
+		(at 130.81 109.22 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -5907,7 +6057,7 @@
 		(dnp no)
 		(uuid "3e8ff1da-4dfe-4f92-b3e8-74f7ebcf7740")
 		(property "Reference" "Q1"
-			(at 133.35 107.9499 0)
+			(at 135.89 107.9499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5916,7 +6066,7 @@
 			)
 		)
 		(property "Value" "BC558"
-			(at 133.35 110.4899 0)
+			(at 135.89 110.4899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5925,7 +6075,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_THT:TO-92_Inline"
-			(at 133.35 107.315 0)
+			(at 135.89 107.315 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5936,7 +6086,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf"
-			(at 128.27 109.22 0)
+			(at 130.81 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5946,7 +6096,7 @@
 			)
 		)
 		(property "Description" "0.1A Ic, 30V Vce, PNP Small Signal Transistor, TO-92"
-			(at 128.27 109.22 0)
+			(at 130.81 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5974,7 +6124,7 @@
 	)
 	(symbol
 		(lib_id "power:+12V")
-		(at 127 86.36 0)
+		(at 129.54 86.36 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5983,7 +6133,7 @@
 		(fields_autoplaced yes)
 		(uuid "42b850ad-20b1-40a6-b969-633b5c42c757")
 		(property "Reference" "#PWR020"
-			(at 127 90.17 0)
+			(at 129.54 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5992,7 +6142,7 @@
 			)
 		)
 		(property "Value" "+12V"
-			(at 127 81.28 0)
+			(at 129.54 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6000,7 +6150,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 127 86.36 0)
+			(at 129.54 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6009,7 +6159,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 127 86.36 0)
+			(at 129.54 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6018,7 +6168,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+12V\""
-			(at 127 86.36 0)
+			(at 129.54 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6040,7 +6190,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 104.14 88.9 0)
+		(at 106.68 88.9 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6049,7 +6199,7 @@
 		(fields_autoplaced yes)
 		(uuid "50be8e04-ec90-4b4e-802c-824d26aa7f78")
 		(property "Reference" "#PWR042"
-			(at 104.14 95.25 0)
+			(at 106.68 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6058,7 +6208,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 104.14 93.98 0)
+			(at 106.68 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6066,7 +6216,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 104.14 88.9 0)
+			(at 106.68 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6075,7 +6225,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 104.14 88.9 0)
+			(at 106.68 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6084,7 +6234,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 104.14 88.9 0)
+			(at 106.68 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6174,7 +6324,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 34.29 107.95 90)
+		(at 44.45 107.95 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6183,7 +6333,7 @@
 		(fields_autoplaced yes)
 		(uuid "54227056-63ef-4bd9-81a5-a1b42b4cf8a2")
 		(property "Reference" "R7"
-			(at 34.29 101.6 90)
+			(at 44.45 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6191,7 +6341,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 34.29 104.14 90)
+			(at 44.45 104.14 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6199,7 +6349,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 34.544 106.934 90)
+			(at 44.704 106.934 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6208,7 +6358,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 34.29 107.95 0)
+			(at 44.45 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6217,7 +6367,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 34.29 107.95 0)
+			(at 44.45 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6378,7 +6528,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 111.76 118.11 90)
+		(at 114.3 118.11 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6387,7 +6537,7 @@
 		(fields_autoplaced yes)
 		(uuid "5c63fe45-8305-42e3-8ca7-0d87624a2c69")
 		(property "Reference" "R6"
-			(at 111.76 111.76 90)
+			(at 114.3 111.76 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6395,7 +6545,7 @@
 			)
 		)
 		(property "Value" "3k3"
-			(at 111.76 114.3 90)
+			(at 114.3 114.3 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6403,7 +6553,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 112.014 117.094 90)
+			(at 114.554 117.094 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6412,7 +6562,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 111.76 118.11 0)
+			(at 114.3 118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6421,7 +6571,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 111.76 118.11 0)
+			(at 114.3 118.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6439,6 +6589,72 @@
 			(project "DMH_VCO_40106_PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "R6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+12V")
+		(at 36.83 57.15 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "621afa99-3698-4448-acd5-2a61d105ea31")
+		(property "Reference" "#PWR03"
+			(at 36.83 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+12V"
+			(at 36.83 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 36.83 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 36.83 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+12V\""
+			(at 36.83 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a2e8904-5a23-4780-87b8-c4df6ece836f")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "#PWR03")
 					(unit 1)
 				)
 			)
@@ -6512,7 +6728,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 50.8 39.37 90)
+		(at 60.96 48.26 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6521,7 +6737,7 @@
 		(fields_autoplaced yes)
 		(uuid "67cf94a0-58b6-4b82-8456-6dcb46d45816")
 		(property "Reference" "TH1"
-			(at 50.8 33.02 90)
+			(at 60.96 41.91 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6529,7 +6745,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 50.8 35.56 90)
+			(at 60.96 44.45 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6537,7 +6753,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 50.8 39.37 0)
+			(at 60.96 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6546,7 +6762,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 39.37 0)
+			(at 60.96 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6555,7 +6771,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 50.8 39.37 0)
+			(at 60.96 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6580,7 +6796,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 57.15 133.35 90)
+		(at 67.31 121.92 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6589,7 +6805,7 @@
 		(fields_autoplaced yes)
 		(uuid "6b0b508a-e7f1-4ff1-8d49-157744931258")
 		(property "Reference" "TH5"
-			(at 57.15 127 90)
+			(at 67.31 115.57 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6597,7 +6813,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 57.15 129.54 90)
+			(at 67.31 118.11 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6605,7 +6821,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 57.15 133.35 0)
+			(at 67.31 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6614,7 +6830,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 57.15 133.35 0)
+			(at 67.31 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6623,7 +6839,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 57.15 133.35 0)
+			(at 67.31 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6648,7 +6864,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 36.83 133.35 0)
+		(at 46.99 121.92 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6656,7 +6872,7 @@
 		(dnp no)
 		(uuid "6b9172ff-a1bd-449b-89ff-439171a9e7c7")
 		(property "Reference" "RV3"
-			(at 34.29 132.0799 0)
+			(at 44.45 120.6499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6665,7 +6881,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 34.29 134.6199 0)
+			(at 44.45 123.1899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6674,7 +6890,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 36.83 133.35 0)
+			(at 46.99 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6683,7 +6899,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 36.83 133.35 0)
+			(at 46.99 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6692,7 +6908,7 @@
 			)
 		)
 		(property "Description" "Exp FM 1 Amt"
-			(at 21.844 133.35 0)
+			(at 32.004 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6791,7 +7007,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_Trim_US")
-		(at 118.11 127 0)
+		(at 120.65 127 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6799,7 +7015,7 @@
 		(dnp no)
 		(uuid "6d52a498-9f38-4108-b7ea-3c5d9215c1c6")
 		(property "Reference" "RV5"
-			(at 115.57 125.7299 0)
+			(at 118.11 125.7299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6808,7 +7024,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 115.57 128.2699 0)
+			(at 118.11 128.2699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6817,7 +7033,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Bourns_3296W_Vertical"
-			(at 118.11 127 0)
+			(at 120.65 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6826,7 +7042,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 118.11 127 0)
+			(at 120.65 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6835,7 +7051,7 @@
 			)
 		)
 		(property "Description" "V/Oct Calibration"
-			(at 109.728 132.08 90)
+			(at 112.268 132.08 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6862,7 +7078,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 46.99 152.4 90)
+		(at 57.15 140.97 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6871,7 +7087,7 @@
 		(fields_autoplaced yes)
 		(uuid "701d67d6-1d5b-4af8-b8dc-39401241cc3a")
 		(property "Reference" "R9"
-			(at 46.99 146.05 90)
+			(at 57.15 134.62 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6879,7 +7095,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 46.99 148.59 90)
+			(at 57.15 137.16 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6887,7 +7103,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 47.244 151.384 90)
+			(at 57.404 139.954 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6896,7 +7112,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 46.99 152.4 0)
+			(at 57.15 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6905,7 +7121,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 46.99 152.4 0)
+			(at 57.15 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7066,7 +7282,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 77.47 116.84 90)
+		(at 87.63 116.84 90)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -7075,7 +7291,7 @@
 		(dnp no)
 		(uuid "768600e6-2c71-4830-a79b-2058b99e7004")
 		(property "Reference" "R10"
-			(at 77.47 123.19 90)
+			(at 87.63 123.19 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7083,7 +7299,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 77.47 120.65 90)
+			(at 87.63 120.65 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7091,7 +7307,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 77.724 117.856 90)
+			(at 87.884 117.856 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7100,7 +7316,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 77.47 116.84 0)
+			(at 87.63 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7109,7 +7325,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 77.47 116.84 0)
+			(at 87.63 116.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7133,74 +7349,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 15.24 67.31 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "794bd708-effe-4ce9-a56d-c70efa2ab1b4")
-		(property "Reference" "#PWR03"
-			(at 15.24 73.66 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 15.24 72.39 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 15.24 67.31 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 15.24 67.31 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 15.24 67.31 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "c299cb04-cac3-4d04-8eed-e1e52b94d514")
-		)
-		(instances
-			(project "VCO mki PCB"
-				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
-					(reference "#PWR03")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Connector:TestPoint")
-		(at 137.16 93.98 0)
+		(at 139.7 93.98 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7208,7 +7358,7 @@
 		(dnp no)
 		(uuid "7a3f9f63-6661-4f70-9554-796c4836e620")
 		(property "Reference" "TP1"
-			(at 139.7 89.4079 0)
+			(at 142.24 89.4079 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7217,7 +7367,7 @@
 			)
 		)
 		(property "Value" "TestPoint"
-			(at 139.7 91.9479 0)
+			(at 142.24 91.9479 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7226,7 +7376,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 142.24 93.98 0)
+			(at 144.78 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7235,7 +7385,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 142.24 93.98 0)
+			(at 144.78 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7244,7 +7394,7 @@
 			)
 		)
 		(property "Description" "test point"
-			(at 137.16 93.98 0)
+			(at 139.7 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7266,7 +7416,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 127 95.25 180)
+		(at 129.54 95.25 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7275,7 +7425,7 @@
 		(fields_autoplaced yes)
 		(uuid "7aedeb88-ff83-4f3a-bd4a-2de9d68a0822")
 		(property "Reference" "R11"
-			(at 129.54 93.9799 0)
+			(at 132.08 93.9799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7284,7 +7434,7 @@
 			)
 		)
 		(property "Value" "1M"
-			(at 129.54 96.5199 0)
+			(at 132.08 96.5199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7293,7 +7443,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 125.984 94.996 90)
+			(at 128.524 94.996 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7302,7 +7452,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 127 95.25 0)
+			(at 129.54 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7311,7 +7461,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 127 95.25 0)
+			(at 129.54 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7336,32 +7486,34 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 21.59 46.99 90)
+		(at 22.86 83.82 0)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "81b7e948-5946-4364-9f76-2455cbaf6a2b")
 		(property "Reference" "R2"
-			(at 21.59 40.64 90)
+			(at 20.32 82.5499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
 		(property "Value" "33k"
-			(at 21.59 43.18 90)
+			(at 20.32 85.0899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 21.844 45.974 90)
+			(at 23.876 83.566 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7370,7 +7522,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 21.59 46.99 0)
+			(at 22.86 83.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7379,7 +7531,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 21.59 46.99 0)
+			(at 22.86 83.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7404,7 +7556,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 36.83 158.75 0)
+		(at 46.99 147.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7412,7 +7564,7 @@
 		(dnp no)
 		(uuid "864e9607-153b-4542-b309-7b9596c0220b")
 		(property "Reference" "#PWR040"
-			(at 36.83 165.1 0)
+			(at 46.99 153.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7421,7 +7573,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 36.83 162.814 0)
+			(at 46.99 151.384 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7429,7 +7581,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 36.83 158.75 0)
+			(at 46.99 147.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7438,7 +7590,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 36.83 158.75 0)
+			(at 46.99 147.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7447,7 +7599,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 36.83 158.75 0)
+			(at 46.99 147.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7462,6 +7614,76 @@
 			(project "DMH_VCO_40106_PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "#PWR040")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
+		(at 36.83 83.82 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "899f38e0-907e-40a1-9671-ca8a4f4918a7")
+		(property "Reference" "R40"
+			(at 34.29 82.5499 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100k"
+			(at 34.29 85.0899 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 35.814 84.074 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 36.83 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 36.83 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "59fbdf2a-8078-4d3d-9c18-195dacf17cbd")
+		)
+		(pin "1"
+			(uuid "8d02fc58-163f-472d-8bdf-f9837603be2d")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R40")
 					(unit 1)
 				)
 			)
@@ -7607,7 +7829,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 26.67 73.66 0)
+		(at 36.83 73.66 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7615,7 +7837,7 @@
 		(dnp no)
 		(uuid "95116ff5-e8ba-485c-9056-08caa02a2fef")
 		(property "Reference" "RV2"
-			(at 24.13 72.3899 0)
+			(at 34.29 72.3899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7624,7 +7846,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 24.13 74.9299 0)
+			(at 34.29 74.9299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7633,7 +7855,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 26.67 73.66 0)
+			(at 36.83 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7642,7 +7864,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 26.67 73.66 0)
+			(at 36.83 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7651,7 +7873,7 @@
 			)
 		)
 		(property "Description" "Fine"
-			(at 21.844 69.85 0)
+			(at 32.004 69.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7819,7 +8041,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 57.15 152.4 90)
+		(at 67.31 140.97 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7828,7 +8050,7 @@
 		(fields_autoplaced yes)
 		(uuid "a0ba07f5-4440-4c30-95d5-cddf684f9052")
 		(property "Reference" "TH6"
-			(at 57.15 146.05 90)
+			(at 67.31 134.62 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7836,7 +8058,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 57.15 148.59 90)
+			(at 67.31 137.16 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7844,7 +8066,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 57.15 152.4 0)
+			(at 67.31 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7853,7 +8075,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 57.15 152.4 0)
+			(at 67.31 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7862,7 +8084,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 57.15 152.4 0)
+			(at 67.31 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7954,7 +8176,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 40.64 39.37 90)
+		(at 50.8 48.26 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7963,7 +8185,7 @@
 		(fields_autoplaced yes)
 		(uuid "a661610d-985e-458c-8614-a04b65a9dbeb")
 		(property "Reference" "R4"
-			(at 40.64 33.02 90)
+			(at 50.8 41.91 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7971,7 +8193,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 40.64 35.56 90)
+			(at 50.8 44.45 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7979,7 +8201,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 40.894 38.354 90)
+			(at 51.054 47.244 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7988,7 +8210,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 40.64 39.37 0)
+			(at 50.8 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7997,7 +8219,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 40.64 39.37 0)
+			(at 50.8 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8022,7 +8244,7 @@
 	)
 	(symbol
 		(lib_id "Amplifier_Operational:TL074")
-		(at 109.22 105.41 0)
+		(at 111.76 105.41 0)
 		(unit 2)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8031,7 +8253,7 @@
 		(fields_autoplaced yes)
 		(uuid "a9cb2ce3-f422-4397-ac16-407fdaf2dd99")
 		(property "Reference" "U4"
-			(at 109.22 95.25 0)
+			(at 111.76 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8039,7 +8261,7 @@
 			)
 		)
 		(property "Value" "TL074"
-			(at 109.22 97.79 0)
+			(at 111.76 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8047,7 +8269,7 @@
 			)
 		)
 		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
-			(at 107.95 102.87 0)
+			(at 110.49 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8056,7 +8278,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
-			(at 110.49 100.33 0)
+			(at 113.03 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8065,7 +8287,7 @@
 			)
 		)
 		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
-			(at 109.22 105.41 0)
+			(at 111.76 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8126,16 +8348,15 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_Trim_US")
-		(at 26.67 83.82 0)
+		(at 57.15 88.9 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "aad5f486-f28b-4bf3-a898-786ee2e7c8fb")
-		(property "Reference" "R3"
-			(at 24.13 82.5499 0)
+		(property "Reference" "RV12"
+			(at 54.864 92.456 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8143,8 +8364,8 @@
 				(justify right)
 			)
 		)
-		(property "Value" "100k"
-			(at 24.13 85.0899 0)
+		(property "Value" "50k"
+			(at 54.864 94.996 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8153,7 +8374,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 26.67 83.82 0)
+			(at 57.15 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8162,7 +8383,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 26.67 83.82 0)
+			(at 57.15 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8171,7 +8392,7 @@
 			)
 		)
 		(property "Description" "Trim-potentiometer, US symbol"
-			(at 26.67 83.82 0)
+			(at 57.15 88.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8191,7 +8412,72 @@
 		(instances
 			(project "VCO mki PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
-					(reference "R3")
+					(reference "RV12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 63.5 91.44 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ab4f7bcd-9c8c-40e7-9655-4524b214aa62")
+		(property "Reference" "#PWR043"
+			(at 63.5 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 63.5 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 63.5 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 63.5 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 63.5 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fea73dd6-c6e4-497d-8ac2-e35cdb5ce900")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "#PWR043")
 					(unit 1)
 				)
 			)
@@ -8267,7 +8553,7 @@
 	)
 	(symbol
 		(lib_id "Connector:TestPoint")
-		(at 152.4 86.36 90)
+		(at 154.94 86.36 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8276,7 +8562,7 @@
 		(fields_autoplaced yes)
 		(uuid "b3517dd2-19a6-4254-a9ae-4f6e9b37a748")
 		(property "Reference" "TP2"
-			(at 149.098 81.28 90)
+			(at 151.638 81.28 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8284,7 +8570,7 @@
 			)
 		)
 		(property "Value" "TestPoint"
-			(at 149.098 83.82 90)
+			(at 151.638 83.82 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8292,7 +8578,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 152.4 81.28 0)
+			(at 154.94 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8301,7 +8587,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 81.28 0)
+			(at 154.94 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8310,7 +8596,7 @@
 			)
 		)
 		(property "Description" "test point"
-			(at 152.4 86.36 0)
+			(at 154.94 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8332,7 +8618,7 @@
 	)
 	(symbol
 		(lib_id "Amplifier_Operational:TL074")
-		(at 77.47 107.95 0)
+		(at 83.82 107.95 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8341,7 +8627,7 @@
 		(fields_autoplaced yes)
 		(uuid "b79ce5b5-c227-46f6-99cc-09596ced13d9")
 		(property "Reference" "U4"
-			(at 77.47 97.79 0)
+			(at 83.82 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8349,7 +8635,7 @@
 			)
 		)
 		(property "Value" "TL074"
-			(at 77.47 100.33 0)
+			(at 83.82 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8357,7 +8643,7 @@
 			)
 		)
 		(property "Footprint" "Package_DIP:DIP-14_W7.62mm_Socket"
-			(at 76.2 105.41 0)
+			(at 82.55 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8366,7 +8652,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.ti.com/lit/ds/symlink/tl071.pdf"
-			(at 78.74 102.87 0)
+			(at 85.09 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8375,7 +8661,7 @@
 			)
 		)
 		(property "Description" "Quad Low-Noise JFET-Input Operational Amplifiers, DIP-14/SOIC-14"
-			(at 77.47 107.95 0)
+			(at 83.82 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8435,74 +8721,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:+12V")
-		(at 17.78 21.59 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "c0253149-3617-44f7-8af8-d53a04fff747")
-		(property "Reference" "#PWR01"
-			(at 17.78 25.4 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "+12V"
-			(at 17.78 16.51 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 17.78 21.59 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 17.78 21.59 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"+12V\""
-			(at 17.78 21.59 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "e9c147c6-86a3-4315-84fc-a4d19e923c6d")
-		)
-		(instances
-			(project "VCO mki PCB"
-				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
-					(reference "#PWR01")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 25.4 35.56 0)
+		(at 22.86 73.66 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8510,7 +8730,7 @@
 		(dnp no)
 		(uuid "c62cbba0-ae25-4d6b-915e-7bf79b6ff4d4")
 		(property "Reference" "RV1"
-			(at 22.86 34.2899 0)
+			(at 20.32 72.3899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8519,7 +8739,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 22.86 36.8299 0)
+			(at 20.32 74.9299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8528,7 +8748,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 25.4 35.56 0)
+			(at 22.86 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8537,7 +8757,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 25.4 35.56 0)
+			(at 22.86 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8546,7 +8766,7 @@
 			)
 		)
 		(property "Description" "Coarse"
-			(at 19.304 32.004 0)
+			(at 16.764 70.104 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8573,7 +8793,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 36.83 152.4 0)
+		(at 46.99 140.97 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8581,7 +8801,7 @@
 		(dnp no)
 		(uuid "c73e43ee-1467-4bd1-8894-cec8720a207b")
 		(property "Reference" "RV4"
-			(at 34.29 151.1299 0)
+			(at 44.45 139.6999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8590,7 +8810,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 34.29 153.6699 0)
+			(at 44.45 142.2399 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8599,7 +8819,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 36.83 152.4 0)
+			(at 46.99 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8608,7 +8828,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 36.83 152.4 0)
+			(at 46.99 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8617,7 +8837,7 @@
 			)
 		)
 		(property "Description" "Exp FM 2 Amt"
-			(at 21.59 152.4 0)
+			(at 31.75 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8644,7 +8864,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 118.11 137.16 0)
+		(at 120.65 137.16 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8653,7 +8873,7 @@
 		(fields_autoplaced yes)
 		(uuid "ca5f716e-0e59-472d-b5e5-6e6461509e5c")
 		(property "Reference" "R38"
-			(at 120.65 135.8899 0)
+			(at 123.19 135.8899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8662,7 +8882,7 @@
 			)
 		)
 		(property "Value" "510R"
-			(at 120.65 138.4299 0)
+			(at 123.19 138.4299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8671,7 +8891,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 119.126 137.414 90)
+			(at 121.666 137.414 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8680,7 +8900,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 118.11 137.16 0)
+			(at 120.65 137.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8689,7 +8909,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 118.11 137.16 0)
+			(at 120.65 137.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8714,16 +8934,15 @@
 	)
 	(symbol
 		(lib_id "Transistor_BJT:BC548")
-		(at 142.24 107.95 0)
+		(at 144.78 107.95 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "cb8f8b25-d9bd-403b-90be-45d638c1831d")
 		(property "Reference" "Q2"
-			(at 147.32 106.6799 0)
+			(at 149.86 109.982 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8732,7 +8951,7 @@
 			)
 		)
 		(property "Value" "BC548"
-			(at 147.32 109.2199 0)
+			(at 149.86 112.522 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8741,7 +8960,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_THT:TO-92_Inline"
-			(at 147.32 109.855 0)
+			(at 149.86 109.855 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8752,7 +8971,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BC550-D.pdf"
-			(at 142.24 107.95 0)
+			(at 144.78 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8762,7 +8981,7 @@
 			)
 		)
 		(property "Description" "0.1A Ic, 30V Vce, Small Signal NPN Transistor, TO-92"
-			(at 142.24 107.95 0)
+			(at 144.78 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8893,6 +9112,76 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R_US")
+		(at 36.83 63.5 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d3689ec9-159f-4dcc-a411-35c8544b7c97")
+		(property "Reference" "R41"
+			(at 34.29 62.2299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100k"
+			(at 34.29 64.7699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 35.814 63.754 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 36.83 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 36.83 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "aebab625-2aad-4083-a636-cddf1523552c")
+		)
+		(pin "1"
+			(uuid "d3fb7e97-5b84-49cf-afb3-904315afc545")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R41")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Amplifier_Operational:TL074")
 		(at 218.44 64.77 0)
 		(unit 3)
@@ -8998,7 +9287,7 @@
 	)
 	(symbol
 		(lib_id "power:-12V")
-		(at 26.67 90.17 180)
+		(at 36.83 90.17 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9007,7 +9296,7 @@
 		(fields_autoplaced yes)
 		(uuid "d5d05cb4-ab9e-407a-8bfe-9564a8296a03")
 		(property "Reference" "#PWR04"
-			(at 26.67 86.36 0)
+			(at 36.83 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9016,7 +9305,7 @@
 			)
 		)
 		(property "Value" "-12V"
-			(at 26.67 95.25 0)
+			(at 36.83 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9024,7 +9313,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 26.67 90.17 0)
+			(at 36.83 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9033,7 +9322,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 26.67 90.17 0)
+			(at 36.83 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9042,7 +9331,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 26.67 90.17 0)
+			(at 36.83 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9064,7 +9353,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 44.45 107.95 90)
+		(at 54.61 107.95 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9073,7 +9362,7 @@
 		(fields_autoplaced yes)
 		(uuid "d6ff5a2e-6143-44eb-b840-fe7bc7c4124e")
 		(property "Reference" "TH4"
-			(at 44.45 101.6 90)
+			(at 54.61 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9081,7 +9370,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 44.45 104.14 90)
+			(at 54.61 104.14 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9089,7 +9378,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 44.45 107.95 0)
+			(at 54.61 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9098,7 +9387,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 44.45 107.95 0)
+			(at 54.61 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9107,7 +9396,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 44.45 107.95 0)
+			(at 54.61 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9132,32 +9421,34 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 21.59 29.21 90)
+		(at 22.86 63.5 0)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
 		(uuid "d90146cb-cc60-488f-83b7-99b7cf5d6ab9")
 		(property "Reference" "R1"
-			(at 21.59 22.86 90)
+			(at 20.32 62.2299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
 		(property "Value" "100k"
-			(at 21.59 25.4 90)
+			(at 20.32 64.7699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 21.844 28.194 90)
+			(at 23.876 63.246 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9166,7 +9457,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 21.59 29.21 0)
+			(at 22.86 63.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9175,7 +9466,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 21.59 29.21 0)
+			(at 22.86 63.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9200,7 +9491,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 93.98 107.95 90)
+		(at 97.79 107.95 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9209,7 +9500,7 @@
 		(fields_autoplaced yes)
 		(uuid "d99d1e5f-c572-4e41-9031-40814d376b85")
 		(property "Reference" "R37"
-			(at 93.98 101.6 90)
+			(at 97.79 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9217,7 +9508,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 93.98 104.14 90)
+			(at 97.79 104.14 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9225,7 +9516,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 94.234 106.934 90)
+			(at 98.044 106.934 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9234,7 +9525,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 93.98 107.95 0)
+			(at 97.79 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9243,7 +9534,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 93.98 107.95 0)
+			(at 97.79 107.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9268,7 +9559,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 118.11 143.51 0)
+		(at 120.65 143.51 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9277,7 +9568,7 @@
 		(fields_autoplaced yes)
 		(uuid "d9dee118-bd8d-46d6-a570-70104a0b3ff0")
 		(property "Reference" "#PWR019"
-			(at 118.11 149.86 0)
+			(at 120.65 149.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9286,7 +9577,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 118.11 148.59 0)
+			(at 120.65 148.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9294,7 +9585,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 118.11 143.51 0)
+			(at 120.65 143.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9303,7 +9594,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 118.11 143.51 0)
+			(at 120.65 143.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9312,7 +9603,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 118.11 143.51 0)
+			(at 120.65 143.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9334,7 +9625,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 36.83 139.7 0)
+		(at 46.99 128.27 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9342,7 +9633,7 @@
 		(dnp no)
 		(uuid "dc4c1fbf-8f63-48ab-a5e8-5cb004c8a344")
 		(property "Reference" "#PWR033"
-			(at 36.83 146.05 0)
+			(at 46.99 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9351,7 +9642,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 36.83 143.51 0)
+			(at 46.99 132.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9359,7 +9650,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 36.83 139.7 0)
+			(at 46.99 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9368,7 +9659,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 36.83 139.7 0)
+			(at 46.99 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9377,7 +9668,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 36.83 139.7 0)
+			(at 46.99 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9464,72 +9755,6 @@
 		)
 	)
 	(symbol
-		(lib_id "power:-12V")
-		(at 17.78 49.53 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "dd94ded9-a350-4be3-9398-9c4b13eba5fa")
-		(property "Reference" "#PWR02"
-			(at 17.78 45.72 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "-12V"
-			(at 17.78 54.61 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 17.78 49.53 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 17.78 49.53 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 17.78 49.53 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "c35fde6a-2a89-4f72-895e-d07b50477fcc")
-		)
-		(instances
-			(project "VCO mki PCB"
-				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
-					(reference "#PWR02")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:R_US")
 		(at 264.16 67.31 270)
 		(unit 1)
@@ -9599,7 +9824,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 57.15 73.66 90)
+		(at 67.31 73.66 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9608,7 +9833,7 @@
 		(fields_autoplaced yes)
 		(uuid "e3501d8c-0ad3-4a53-9bfd-fdddf154685c")
 		(property "Reference" "TH2"
-			(at 57.15 67.31 90)
+			(at 67.31 67.31 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9616,7 +9841,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 57.15 69.85 90)
+			(at 67.31 69.85 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9624,7 +9849,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 57.15 73.66 0)
+			(at 67.31 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9633,7 +9858,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 57.15 73.66 0)
+			(at 67.31 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9642,7 +9867,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 57.15 73.66 0)
+			(at 67.31 73.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9660,6 +9885,75 @@
 			(project "VCO mki PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "TH2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
+		(at 67.31 82.55 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "eec8db87-a26f-416a-a556-37a30194f425")
+		(property "Reference" "R43"
+			(at 65.024 88.138 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1M"
+			(at 66.04 85.852 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 67.056 83.566 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 67.31 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 67.31 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "dd2b01bf-9fe3-4976-9e9e-7db8e8a8ae65")
+		)
+		(pin "1"
+			(uuid "d7a7c0a4-2539-4a05-8df2-99d98e29c710")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R43")
 					(unit 1)
 				)
 			)

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2878,12 +2878,6 @@
 		(uuid "23d18312-e5fd-4043-94fe-4ae1dafac028")
 	)
 	(junction
-		(at 52.07 73.66)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "2f088860-0d76-4f91-95f8-6a88de66696d")
-	)
-	(junction
 		(at 139.7 100.33)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2912,12 +2906,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "5118ec97-292c-4e63-b0c1-0807cda69d81")
-	)
-	(junction
-		(at 72.39 73.66)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "52e56aaa-83b4-4f65-90dc-4bb9b82232f1")
 	)
 	(junction
 		(at 72.39 121.92)
@@ -2966,6 +2954,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "87560534-6723-4cfc-b5e1-e63f9ec9f5a5")
+	)
+	(junction
+		(at 72.39 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9c644b43-6796-4bca-817a-2fe3b31d7f36")
 	)
 	(junction
 		(at 92.71 107.95)
@@ -3037,16 +3031,6 @@
 	)
 	(wire
 		(pts
-			(xy 57.15 77.47) (xy 52.07 77.47)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "02b5da5f-cecd-4f87-8932-ff756249eff3")
-	)
-	(wire
-		(pts
 			(xy 180.34 24.13) (xy 182.88 24.13)
 		)
 		(stroke
@@ -3067,17 +3051,7 @@
 	)
 	(wire
 		(pts
-			(xy 52.07 73.66) (xy 53.34 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "081cea57-d0c1-46d6-a3ad-e352dcb2e082")
-	)
-	(wire
-		(pts
-			(xy 27.94 48.26) (xy 46.99 48.26)
+			(xy 27.94 48.26) (xy 53.34 48.26)
 		)
 		(stroke
 			(width 0)
@@ -3124,6 +3098,16 @@
 			(type default)
 		)
 		(uuid "0bd30e03-08ee-433a-9997-14a4303aa028")
+	)
+	(wire
+		(pts
+			(xy 60.96 60.96) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d491a9f-a681-471e-a40a-9b457fef6755")
 	)
 	(wire
 		(pts
@@ -3237,7 +3221,7 @@
 	)
 	(wire
 		(pts
-			(xy 72.39 73.66) (xy 72.39 48.26)
+			(xy 72.39 48.26) (xy 72.39 60.96)
 		)
 		(stroke
 			(width 0)
@@ -3394,6 +3378,16 @@
 			(type default)
 		)
 		(uuid "36f8ff44-1d8e-42c1-8ef2-aa20df372845")
+	)
+	(wire
+		(pts
+			(xy 41.91 54.61) (xy 46.99 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "37670c69-d321-4ebc-b2a8-4d4e96c6ac7b")
 	)
 	(wire
 		(pts
@@ -3567,6 +3561,16 @@
 	)
 	(wire
 		(pts
+			(xy 46.99 64.77) (xy 46.99 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "51764546-3e90-4055-a909-bd95db6c7465")
+	)
+	(wire
+		(pts
 			(xy 199.39 71.12) (xy 210.82 71.12)
 		)
 		(stroke
@@ -3614,16 +3618,6 @@
 			(type default)
 		)
 		(uuid "5c948a34-0c2c-464e-a01b-65ad140c4ef2")
-	)
-	(wire
-		(pts
-			(xy 40.64 73.66) (xy 43.18 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5d7497c4-f1c6-43da-b8c4-a131856e840e")
 	)
 	(wire
 		(pts
@@ -3757,7 +3751,7 @@
 	)
 	(wire
 		(pts
-			(xy 71.12 73.66) (xy 72.39 73.66)
+			(xy 71.12 60.96) (xy 72.39 60.96)
 		)
 		(stroke
 			(width 0)
@@ -3837,13 +3831,13 @@
 	)
 	(wire
 		(pts
-			(xy 72.39 73.66) (xy 72.39 82.55)
+			(xy 63.5 69.85) (xy 63.5 71.12)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "82df5172-2857-4796-8f45-3de215f2ee74")
+		(uuid "84cee701-46b0-4438-8067-3c2dbea6e584")
 	)
 	(wire
 		(pts
@@ -3924,16 +3918,6 @@
 			(type default)
 		)
 		(uuid "946a8b10-0d43-4fc1-abc9-cb9bf0879ab9")
-	)
-	(wire
-		(pts
-			(xy 50.8 73.66) (xy 52.07 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "95246720-10ba-4e4e-aea5-1636c6584648")
 	)
 	(wire
 		(pts
@@ -4057,7 +4041,7 @@
 	)
 	(wire
 		(pts
-			(xy 54.61 48.26) (xy 57.15 48.26)
+			(xy 60.96 48.26) (xy 63.5 48.26)
 		)
 		(stroke
 			(width 0)
@@ -4084,6 +4068,16 @@
 			(type default)
 		)
 		(uuid "a9cc4e4e-5365-4c59-9f9b-1c35f11c062c")
+	)
+	(wire
+		(pts
+			(xy 50.8 60.96) (xy 53.34 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aa5eff59-7b48-48a1-a1d4-5c736e17cf7e")
 	)
 	(wire
 		(pts
@@ -4127,16 +4121,6 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 73.66) (xy 63.5 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "adf41306-b614-4256-8223-63f28cc7b268")
-	)
-	(wire
-		(pts
 			(xy 154.94 86.36) (xy 157.48 86.36)
 		)
 		(stroke
@@ -4167,16 +4151,6 @@
 	)
 	(wire
 		(pts
-			(xy 52.07 77.47) (xy 52.07 73.66)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b0eabf79-a108-4076-8c06-16e7a07c776d")
-	)
-	(wire
-		(pts
 			(xy 36.83 57.15) (xy 36.83 58.42)
 		)
 		(stroke
@@ -4204,6 +4178,16 @@
 			(type default)
 		)
 		(uuid "b37ef866-eabf-43ff-93e4-ba31fc55df7f")
+	)
+	(wire
+		(pts
+			(xy 41.91 54.61) (xy 41.91 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b5e8c891-ce92-4fce-afce-824cc33b7091")
 	)
 	(wire
 		(pts
@@ -4277,7 +4261,7 @@
 	)
 	(wire
 		(pts
-			(xy 64.77 48.26) (xy 72.39 48.26)
+			(xy 71.12 48.26) (xy 72.39 48.26)
 		)
 		(stroke
 			(width 0)
@@ -4327,6 +4311,26 @@
 	)
 	(wire
 		(pts
+			(xy 40.64 73.66) (xy 41.91 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd2f2026-1402-4f27-b24e-f9482d8262aa")
+	)
+	(wire
+		(pts
+			(xy 58.42 69.85) (xy 63.5 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdd618c1-3ffd-42b3-b17c-470c8ff3ef0c")
+	)
+	(wire
+		(pts
 			(xy 147.32 113.03) (xy 147.32 115.57)
 		)
 		(stroke
@@ -4354,6 +4358,16 @@
 			(type default)
 		)
 		(uuid "d133aa6a-56eb-495c-9f9b-d7e25edb655d")
+	)
+	(wire
+		(pts
+			(xy 46.99 54.61) (xy 46.99 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d51ee62e-9eb0-476a-8151-202c9ed13744")
 	)
 	(wire
 		(pts
@@ -4404,6 +4418,16 @@
 			(type default)
 		)
 		(uuid "dfd10b9a-4246-4eef-beee-81fb3f43496b")
+	)
+	(wire
+		(pts
+			(xy 46.99 69.85) (xy 50.8 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e0b49a74-9b41-4042-9ef3-2cddb624c05f")
 	)
 	(wire
 		(pts
@@ -4494,6 +4518,16 @@
 			(type default)
 		)
 		(uuid "f12e0476-ca12-4439-bbba-9226f312b951")
+	)
+	(wire
+		(pts
+			(xy 72.39 60.96) (xy 72.39 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f36e7e88-16f3-432a-9aa3-ee9260743e69")
 	)
 	(wire
 		(pts
@@ -4591,11 +4625,12 @@
 	)
 	(text "Cermet trimpots pinout:\nwhen viewing the trimpot from above,\n1 = left = fully CCW\n2 = middle\n3 = rigth = fully CW"
 		(exclude_from_sim no)
-		(at 134.112 154.94 0)
+		(at 15.748 32.766 0)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
+			(justify left)
 		)
 		(uuid "67f720f6-9a75-490f-bca9-4bca511e7ac3")
 	)
@@ -4611,7 +4646,7 @@
 	)
 	(text "RD09 pots pinout:\nwhen viewing the pot from above and the pins are on the south side,\n1 = right = fully CW\n2 = middle\n3 = left = fully CCW"
 		(exclude_from_sim no)
-		(at 53.594 20.32 0)
+		(at 16.002 20.32 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4706,7 +4741,8 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_Trim_US")
-		(at 57.15 73.66 270)
+		(at 46.99 60.96 0)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4714,7 +4750,7 @@
 		(dnp no)
 		(uuid "01e8a046-fa9f-4d17-9a61-8e7d9ee2f54d")
 		(property "Reference" "RV11"
-			(at 57.15 67.31 90)
+			(at 51.308 62.738 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4722,7 +4758,7 @@
 			)
 		)
 		(property "Value" "1M"
-			(at 57.15 69.85 90)
+			(at 51.308 65.278 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4730,7 +4766,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 57.15 73.66 0)
+			(at 46.99 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4739,7 +4775,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 57.15 73.66 0)
+			(at 46.99 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4747,13 +4783,12 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Trim-potentiometer, US symbol"
-			(at 57.15 73.66 0)
+		(property "Description" "Fine Range"
+			(at 43.434 61.214 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
 			)
 		)
 		(pin "2"
@@ -5550,6 +5585,75 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
+		(at 54.61 69.85 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2ad4ea3a-b5b4-4f29-ba88-8391960f4c56")
+		(property "Reference" "R3"
+			(at 55.88 72.644 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "68k"
+			(at 56.896 75.184 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 54.356 70.866 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 54.61 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 54.61 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "50adf307-4be7-45ad-9395-15c6af08ff00")
+		)
+		(pin "1"
+			(uuid "f8356224-bcee-4eb2-ae64-0409398d4456")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
 		(at 236.22 71.12 0)
 		(mirror y)
 		(unit 1)
@@ -5914,7 +6018,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 46.99 73.66 90)
+		(at 57.15 60.96 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5923,7 +6027,7 @@
 		(fields_autoplaced yes)
 		(uuid "37d7652a-b7d0-40b9-848a-d1215cde57fa")
 		(property "Reference" "R39"
-			(at 46.99 67.31 90)
+			(at 57.15 54.61 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5931,7 +6035,7 @@
 			)
 		)
 		(property "Value" "300k"
-			(at 46.99 69.85 90)
+			(at 57.15 57.15 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5939,7 +6043,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 47.244 72.644 90)
+			(at 57.404 59.944 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5948,7 +6052,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 46.99 73.66 0)
+			(at 57.15 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5957,7 +6061,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 46.99 73.66 0)
+			(at 57.15 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6728,7 +6832,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 60.96 48.26 90)
+		(at 67.31 48.26 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6737,7 +6841,7 @@
 		(fields_autoplaced yes)
 		(uuid "67cf94a0-58b6-4b82-8456-6dcb46d45816")
 		(property "Reference" "TH1"
-			(at 60.96 41.91 90)
+			(at 67.31 41.91 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6745,7 +6849,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 60.96 44.45 90)
+			(at 67.31 44.45 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6753,7 +6857,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 60.96 48.26 0)
+			(at 67.31 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6762,7 +6866,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 60.96 48.26 0)
+			(at 67.31 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6771,7 +6875,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 60.96 48.26 0)
+			(at 67.31 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8176,7 +8280,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 50.8 48.26 90)
+		(at 57.15 48.26 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8185,7 +8289,7 @@
 		(fields_autoplaced yes)
 		(uuid "a661610d-985e-458c-8614-a04b65a9dbeb")
 		(property "Reference" "R4"
-			(at 50.8 41.91 90)
+			(at 57.15 41.91 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8193,7 +8297,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 50.8 44.45 90)
+			(at 57.15 44.45 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8201,7 +8305,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 51.054 47.244 90)
+			(at 57.404 47.244 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8210,7 +8314,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 48.26 0)
+			(at 57.15 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8219,7 +8323,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 50.8 48.26 0)
+			(at 57.15 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8398,6 +8502,14 @@
 					(size 1.27 1.27)
 				)
 				(hide yes)
+			)
+		)
+		(property "Function" "Centering"
+			(at 56.642 97.028 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
 			)
 		)
 		(pin "2"
@@ -8715,6 +8827,71 @@
 			(project "DMH_VCO_40106_PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "U4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 63.5 71.12 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c14e6133-c287-442e-982d-a66fddf37b81")
+		(property "Reference" "#PWR01"
+			(at 63.5 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 63.5 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 63.5 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 63.5 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 63.5 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0099a099-9cd2-45e9-a050-4808458bcd90")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "#PWR01")
 					(unit 1)
 				)
 			)
@@ -9824,7 +10001,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 67.31 73.66 90)
+		(at 67.31 60.96 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9833,7 +10010,7 @@
 		(fields_autoplaced yes)
 		(uuid "e3501d8c-0ad3-4a53-9bfd-fdddf154685c")
 		(property "Reference" "TH2"
-			(at 67.31 67.31 90)
+			(at 67.31 54.61 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9841,7 +10018,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 67.31 69.85 90)
+			(at 67.31 57.15 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9849,7 +10026,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 67.31 73.66 0)
+			(at 67.31 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9858,7 +10035,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 67.31 73.66 0)
+			(at 67.31 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9867,7 +10044,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 67.31 73.66 0)
+			(at 67.31 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2932,10 +2932,28 @@
 		(uuid "6c673bc1-7633-4acd-b30f-bfa356b79327")
 	)
 	(junction
+		(at 199.39 78.74)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6df9aa69-897d-44dd-bb06-07c119dab42c")
+	)
+	(junction
 		(at 157.48 86.36)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "71b63799-edab-47a1-8541-dbe29f759bd2")
+	)
+	(junction
+		(at 199.39 99.06)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "77ecdf80-828f-46f8-ad53-36dba6ca9433")
+	)
+	(junction
+		(at 170.18 49.53)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "77ed7710-4d50-4dd5-a1e0-8061ba462e79")
 	)
 	(junction
 		(at 236.22 64.77)
@@ -2974,6 +2992,12 @@
 		(uuid "abcdb0d0-94b4-4cc5-a632-23de5d93fa17")
 	)
 	(junction
+		(at 199.39 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b097906f-dd00-4f76-b6f5-68782aae8008")
+	)
+	(junction
 		(at 257.81 67.31)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2984,18 +3008,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c993f72d-f12c-43f0-a475-b9af82e8a6af")
-	)
-	(junction
-		(at 173.99 71.12)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "cb4d51a7-4bec-44fe-a7fd-ea304529732b")
-	)
-	(junction
-		(at 199.39 71.12)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "cd45eacf-dd4b-447d-915a-ff112a50087e")
 	)
 	(junction
 		(at 199.39 67.31)
@@ -3041,16 +3053,6 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 71.12) (xy 199.39 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "0804a9e7-ad2e-496b-9eb1-27ea37144d52")
-	)
-	(wire
-		(pts
 			(xy 27.94 48.26) (xy 53.34 48.26)
 		)
 		(stroke
@@ -3071,6 +3073,16 @@
 	)
 	(wire
 		(pts
+			(xy 185.42 44.45) (xy 184.15 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "08ded45a-1a65-45d8-8f1d-bb31a816038b")
+	)
+	(wire
+		(pts
 			(xy 179.07 86.36) (xy 173.99 86.36)
 		)
 		(stroke
@@ -3078,16 +3090,6 @@
 			(type default)
 		)
 		(uuid "0939e2e9-697d-4a4c-b98c-441298cd72ba")
-	)
-	(wire
-		(pts
-			(xy 173.99 71.12) (xy 176.53 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "09ee2c48-3425-4c28-8710-c1713cf77152")
 	)
 	(wire
 		(pts
@@ -3118,6 +3120,16 @@
 			(type default)
 		)
 		(uuid "0db4ce3e-c20f-40a8-a8f6-0859c8e5c928")
+	)
+	(wire
+		(pts
+			(xy 182.88 99.06) (xy 199.39 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0ddfd1f5-c972-4229-84d0-7268434422bb")
 	)
 	(wire
 		(pts
@@ -3188,6 +3200,26 @@
 			(type default)
 		)
 		(uuid "1ae4f7cf-7cda-44e2-a88d-b67229b9f7b0")
+	)
+	(wire
+		(pts
+			(xy 182.88 69.85) (xy 182.88 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1bb0fb52-6832-425a-8631-587e1f4114b0")
+	)
+	(wire
+		(pts
+			(xy 175.26 54.61) (xy 175.26 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1dc3fffa-7dd8-4d3a-ae83-235a0614f221")
 	)
 	(wire
 		(pts
@@ -3331,16 +3363,6 @@
 	)
 	(wire
 		(pts
-			(xy 173.99 77.47) (xy 173.99 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3321e833-6dc7-4352-9e05-f1d0e5757cc3")
-	)
-	(wire
-		(pts
 			(xy 91.44 116.84) (xy 92.71 116.84)
 		)
 		(stroke
@@ -3471,6 +3493,16 @@
 	)
 	(wire
 		(pts
+			(xy 170.18 49.53) (xy 175.26 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "420e7f24-4f8d-4fce-910f-9f4ed6c35c8e")
+	)
+	(wire
+		(pts
 			(xy 247.65 26.67) (xy 251.46 26.67)
 		)
 		(stroke
@@ -3571,7 +3603,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 71.12) (xy 210.82 71.12)
+			(xy 199.39 74.93) (xy 210.82 74.93)
 		)
 		(stroke
 			(width 0)
@@ -3631,6 +3663,16 @@
 	)
 	(wire
 		(pts
+			(xy 199.39 78.74) (xy 199.39 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "61db4e11-3031-4a4c-96f6-cd66885628ef")
+	)
+	(wire
+		(pts
 			(xy 162.56 21.59) (xy 157.48 21.59)
 		)
 		(stroke
@@ -3671,13 +3713,33 @@
 	)
 	(wire
 		(pts
-			(xy 180.34 74.93) (xy 180.34 77.47)
+			(xy 185.42 49.53) (xy 185.42 44.45)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "73c7703e-5a96-47c3-a4a4-84fc33fab21a")
+		(uuid "68964ae3-a49f-4cb1-8966-a5f2741d9354")
+	)
+	(wire
+		(pts
+			(xy 170.18 58.42) (xy 170.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6fb5efe8-d5cb-4c7c-afb3-1e60c74f0c06")
+	)
+	(wire
+		(pts
+			(xy 182.88 78.74) (xy 182.88 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7000f40f-d9c9-469e-8293-c2934e02dbfa")
 	)
 	(wire
 		(pts
@@ -3711,16 +3773,6 @@
 	)
 	(wire
 		(pts
-			(xy 184.15 71.12) (xy 187.96 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "78a91eb9-c580-4367-aa0f-2ea19bad3a4c")
-	)
-	(wire
-		(pts
 			(xy 46.99 125.73) (xy 46.99 128.27)
 		)
 		(stroke
@@ -3728,16 +3780,6 @@
 			(type default)
 		)
 		(uuid "78d9bf0f-d4bc-4213-89a8-d8e168154eb0")
-	)
-	(wire
-		(pts
-			(xy 180.34 77.47) (xy 173.99 77.47)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "79d9a9df-b964-4ec4-87eb-f78462d6860e")
 	)
 	(wire
 		(pts
@@ -3771,7 +3813,7 @@
 	)
 	(wire
 		(pts
-			(xy 170.18 40.64) (xy 170.18 45.72)
+			(xy 170.18 38.1) (xy 170.18 40.64)
 		)
 		(stroke
 			(width 0)
@@ -3848,6 +3890,16 @@
 			(type default)
 		)
 		(uuid "8511b0d9-93c0-4021-bfb5-22517beaa5c9")
+	)
+	(wire
+		(pts
+			(xy 204.47 78.74) (xy 199.39 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86147f57-028b-443e-897b-e07c24cfb929")
 	)
 	(wire
 		(pts
@@ -3931,6 +3983,16 @@
 	)
 	(wire
 		(pts
+			(xy 186.69 74.93) (xy 189.23 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "970be65a-bc2b-4a18-8d1f-d1f7b8ee8081")
+	)
+	(wire
+		(pts
 			(xy 133.35 100.33) (xy 139.7 100.33)
 		)
 		(stroke
@@ -3948,6 +4010,16 @@
 			(type default)
 		)
 		(uuid "977b9dea-79b2-4d8e-a995-46af7402f650")
+	)
+	(wire
+		(pts
+			(xy 204.47 83.82) (xy 204.47 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "99003713-9c98-4043-9b30-b514c6c9f1f0")
 	)
 	(wire
 		(pts
@@ -4001,7 +4073,7 @@
 	)
 	(wire
 		(pts
-			(xy 184.15 49.53) (xy 199.39 49.53)
+			(xy 185.42 49.53) (xy 199.39 49.53)
 		)
 		(stroke
 			(width 0)
@@ -4031,13 +4103,23 @@
 	)
 	(wire
 		(pts
-			(xy 170.18 53.34) (xy 170.18 57.15)
+			(xy 199.39 97.79) (xy 199.39 99.06)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a2007bb7-46be-410d-b0ac-d8bf1c20b264")
+		(uuid "a612a969-9f70-4699-a9c7-cdac7283bfc1")
+	)
+	(wire
+		(pts
+			(xy 203.2 83.82) (xy 204.47 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a7246288-a782-47fc-b1f8-8bb38bd98fab")
 	)
 	(wire
 		(pts
@@ -4131,13 +4213,23 @@
 	)
 	(wire
 		(pts
-			(xy 210.82 77.47) (xy 210.82 71.12)
+			(xy 210.82 77.47) (xy 210.82 74.93)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "af46a02e-75d2-4668-97d3-2ffb6453b71f")
+	)
+	(wire
+		(pts
+			(xy 170.18 49.53) (xy 170.18 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "afa4dfb9-185e-4416-8f72-70ca87f7bfe3")
 	)
 	(wire
 		(pts
@@ -4161,7 +4253,7 @@
 	)
 	(wire
 		(pts
-			(xy 173.99 49.53) (xy 176.53 49.53)
+			(xy 173.99 44.45) (xy 176.53 44.45)
 		)
 		(stroke
 			(width 0)
@@ -4188,16 +4280,6 @@
 			(type default)
 		)
 		(uuid "b5e8c891-ce92-4fce-afce-824cc33b7091")
-	)
-	(wire
-		(pts
-			(xy 199.39 82.55) (xy 199.39 86.36)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b609fdae-1d0d-4f80-a521-e7672660e1a1")
 	)
 	(wire
 		(pts
@@ -4381,6 +4463,16 @@
 	)
 	(wire
 		(pts
+			(xy 199.39 87.63) (xy 199.39 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8f97ee6-359d-4c29-b467-aa85827ae3dd")
+	)
+	(wire
+		(pts
 			(xy 35.56 134.62) (xy 46.99 134.62)
 		)
 		(stroke
@@ -4451,17 +4543,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 67.31) (xy 199.39 71.12)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e2bcc9df-42a8-490c-a1f1-8708882823d4")
-	)
-	(wire
-		(pts
-			(xy 195.58 71.12) (xy 199.39 71.12)
+			(xy 196.85 74.93) (xy 199.39 74.93)
 		)
 		(stroke
 			(width 0)
@@ -4478,6 +4560,16 @@
 			(type default)
 		)
 		(uuid "e5e6fe3e-939d-4f42-b041-daa36d907c32")
+	)
+	(wire
+		(pts
+			(xy 170.18 48.26) (xy 170.18 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6046022-2e12-4014-87a0-4a01dd5369cc")
 	)
 	(wire
 		(pts
@@ -4511,6 +4603,36 @@
 	)
 	(wire
 		(pts
+			(xy 171.45 69.85) (xy 182.88 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed47215b-8097-4521-a679-85fbe0638242")
+	)
+	(wire
+		(pts
+			(xy 199.39 67.31) (xy 199.39 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed6cc48c-86f8-4993-9c0a-e855dbc3925b")
+	)
+	(wire
+		(pts
+			(xy 199.39 74.93) (xy 199.39 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef6983de-1702-4b2d-a310-d239ab8d18b7")
+	)
+	(wire
+		(pts
 			(xy 60.96 121.92) (xy 63.5 121.92)
 		)
 		(stroke
@@ -4541,6 +4663,16 @@
 	)
 	(wire
 		(pts
+			(xy 173.99 54.61) (xy 175.26 54.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6b7cace-6ade-45b8-99a2-5c8422e156fc")
+	)
+	(wire
+		(pts
 			(xy 50.8 88.9) (xy 53.34 88.9)
 		)
 		(stroke
@@ -4551,13 +4683,13 @@
 	)
 	(wire
 		(pts
-			(xy 171.45 71.12) (xy 173.99 71.12)
+			(xy 199.39 99.06) (xy 199.39 100.33)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f9ca19f0-92fd-4d1a-9d8c-3859b952a4d8")
+		(uuid "fbac7844-5ce2-4bd8-a612-b2383aca452a")
 	)
 	(wire
 		(pts
@@ -4589,40 +4721,6 @@
 		)
 		(uuid "fd8084d3-ff94-4c24-8174-321305e91580")
 	)
-	(circle
-		(center 202.692 80.772)
-		(radius 6.8392)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(fill
-			(type none)
-		)
-		(uuid 1ff8bbd6-1d59-42b5-8ac5-baac6cc7c35d)
-	)
-	(circle
-		(center 179.832 69.342)
-		(radius 6.8392)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(fill
-			(type none)
-		)
-		(uuid d4adb3d3-ecfb-444c-9c62-edbf6d0f33fc)
-	)
-	(text "used 100k for now"
-		(exclude_from_sim no)
-		(at 181.102 76.962 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-		)
-		(uuid "09690317-5714-412a-a1bf-9b2a232140d1")
-	)
 	(text "Cermet trimpots pinout:\nwhen viewing the trimpot from above,\n1 = left = fully CCW\n2 = middle\n3 = rigth = fully CW"
 		(exclude_from_sim no)
 		(at 15.748 32.766 0)
@@ -4633,16 +4731,6 @@
 			(justify left)
 		)
 		(uuid "67f720f6-9a75-490f-bca9-4bca511e7ac3")
-	)
-	(text "used 10k for now,\nmight need trimpot"
-		(exclude_from_sim no)
-		(at 198.628 83.82 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-		)
-		(uuid "9897344e-1de7-4a91-8b37-57a4ed105914")
 	)
 	(text "RD09 pots pinout:\nwhen viewing the pot from above and the pins are on the south side,\n1 = right = fully CW\n2 = middle\n3 = left = fully CCW"
 		(exclude_from_sim no)
@@ -4681,7 +4769,7 @@
 	)
 	(hierarchical_label "PW Mod In"
 		(shape input)
-		(at 171.45 71.12 180)
+		(at 171.45 69.85 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4811,7 +4899,7 @@
 	)
 	(symbol
 		(lib_id "power:+12V")
-		(at 170.18 40.64 0)
+		(at 170.18 38.1 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4820,7 +4908,7 @@
 		(fields_autoplaced yes)
 		(uuid "091bfedf-6f97-41e3-aa55-33f7b5241cba")
 		(property "Reference" "#PWR026"
-			(at 170.18 44.45 0)
+			(at 170.18 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4829,7 +4917,7 @@
 			)
 		)
 		(property "Value" "+12V"
-			(at 170.18 35.56 0)
+			(at 170.18 33.02 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4837,7 +4925,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 170.18 40.64 0)
+			(at 170.18 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4846,7 +4934,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 170.18 40.64 0)
+			(at 170.18 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4855,7 +4943,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+12V\""
-			(at 170.18 40.64 0)
+			(at 170.18 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5009,76 +5097,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R_US")
-		(at 199.39 78.74 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "131f8aaf-78c0-407e-a103-1dd82ffe84d2")
-		(property "Reference" "R15"
-			(at 201.93 77.4699 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "14k"
-			(at 201.93 80.0099 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 200.406 78.994 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 199.39 78.74 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor, US symbol"
-			(at 199.39 78.74 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "29600143-42bc-4bcc-9b5f-5c6e0357e130")
-		)
-		(pin "1"
-			(uuid "0eea84f8-a844-4afa-927f-b14ecfc6a362")
-		)
-		(instances
-			(project "VCO mki PCB"
-				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
-					(reference "R15")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:-12V")
 		(at 133.35 115.57 180)
 		(unit 1)
@@ -5213,7 +5231,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 199.39 86.36 0)
+		(at 199.39 100.33 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -5222,7 +5240,7 @@
 		(fields_autoplaced yes)
 		(uuid "16dc414e-558a-41ea-90fb-93a2a3dcf463")
 		(property "Reference" "#PWR027"
-			(at 199.39 92.71 0)
+			(at 199.39 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5231,7 +5249,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 199.39 91.44 0)
+			(at 199.39 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5239,7 +5257,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 199.39 86.36 0)
+			(at 199.39 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5248,7 +5266,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 199.39 86.36 0)
+			(at 199.39 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5257,7 +5275,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 199.39 86.36 0)
+			(at 199.39 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5508,6 +5526,86 @@
 			(project "DMH_VCO_40106_PCB"
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "#PWR041")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Potentiometer_Trim_US")
+		(at 170.18 54.61 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "27c79228-8a3e-4d12-9d17-e0ae6c6a19b0")
+		(property "Reference" "RV14"
+			(at 166.624 52.324 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "10k"
+			(at 164.084 52.324 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 170.18 54.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 170.18 54.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Trim-potentiometer, US symbol"
+			(at 170.18 54.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Function" "PW balance"
+			(at 161.29 56.388 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "2d3355af-240a-4771-bfa8-6f5c9217ffcb")
+		)
+		(pin "1"
+			(uuid "efc23848-baa9-44d1-914c-c05a55c797d0")
+		)
+		(pin "3"
+			(uuid "cbfbd666-ad2e-4f43-bbb8-880fc49a7de0")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "RV14")
 					(unit 1)
 				)
 			)
@@ -5803,6 +5901,76 @@
 			(project ""
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_US")
+		(at 199.39 93.98 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2e7f2d71-8f74-4ff9-bb35-90ed014ab3cf")
+		(property "Reference" "R5"
+			(at 196.85 92.7099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "10k"
+			(at 196.85 95.2499 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 198.374 94.234 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 199.39 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, US symbol"
+			(at 199.39 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "495af24a-ad7f-47c3-aa6d-b0dbb22e4407")
+		)
+		(pin "1"
+			(uuid "89643aad-aa51-439d-8f4e-c53194895938")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "R5")
 					(unit 1)
 				)
 			)
@@ -6360,7 +6528,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 180.34 49.53 270)
+		(at 180.34 44.45 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6369,15 +6537,15 @@
 		(fields_autoplaced yes)
 		(uuid "52a4f955-fa0c-490c-a610-8ae8f7212c10")
 		(property "Reference" "R13"
-			(at 180.34 43.18 90)
+			(at 180.34 38.1 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 			)
 		)
-		(property "Value" "100k"
-			(at 180.34 45.72 90)
+		(property "Value" "68k"
+			(at 180.34 40.64 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6385,7 +6553,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 180.086 50.546 90)
+			(at 180.086 45.466 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6394,7 +6562,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 180.34 49.53 0)
+			(at 180.34 44.45 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6403,7 +6571,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 180.34 49.53 0)
+			(at 180.34 44.45 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6766,7 +6934,7 @@
 	)
 	(symbol
 		(lib_id "power:-12V")
-		(at 170.18 57.15 180)
+		(at 170.18 60.96 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6775,7 +6943,7 @@
 		(fields_autoplaced yes)
 		(uuid "655f2b20-82cc-449e-b94c-225ab8cffa39")
 		(property "Reference" "#PWR025"
-			(at 170.18 53.34 0)
+			(at 170.18 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6784,7 +6952,7 @@
 			)
 		)
 		(property "Value" "-12V"
-			(at 170.18 62.23 0)
+			(at 170.18 66.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6792,7 +6960,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 170.18 57.15 0)
+			(at 170.18 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6801,7 +6969,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 170.18 57.15 0)
+			(at 170.18 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6810,7 +6978,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"-12V\""
-			(at 170.18 57.15 0)
+			(at 170.18 60.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7039,7 +7207,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 170.18 49.53 0)
+		(at 170.18 44.45 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -7048,7 +7216,7 @@
 		(dnp no)
 		(uuid "6c76a797-1492-418c-8b33-84bc3d97c3c5")
 		(property "Reference" "RV6"
-			(at 167.64 50.8001 0)
+			(at 167.64 45.7201 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7057,7 +7225,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 167.64 48.2601 0)
+			(at 167.64 43.1801 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7066,7 +7234,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 170.18 49.53 0)
+			(at 170.18 44.45 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7075,7 +7243,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 170.18 49.53 0)
+			(at 170.18 44.45 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7084,7 +7252,7 @@
 			)
 		)
 		(property "Description" "Pulse Width"
-			(at 161.29 49.53 90)
+			(at 161.29 41.91 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7589,6 +7757,86 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R_Potentiometer_Trim_US")
+		(at 199.39 83.82 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7dd7613e-2d9a-47ab-9f50-6c407d29577c")
+		(property "Reference" "RV13"
+			(at 195.834 81.534 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "100k"
+			(at 193.294 81.534 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
+			(at 199.39 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 199.39 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Trim-potentiometer, US symbol"
+			(at 199.39 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Function" "PWM Range"
+			(at 191.262 83.312 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "83e310bb-704c-43c0-bb4a-83724c420117")
+		)
+		(pin "1"
+			(uuid "bb1cbedc-6e07-4747-9b8c-6a4b9f396bbe")
+		)
+		(pin "3"
+			(uuid "62a48031-6a5c-4f15-a70c-a9a1ce767eca")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "RV13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R_US")
 		(at 22.86 83.82 0)
 		(mirror x)
@@ -7865,7 +8113,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 191.77 71.12 270)
+		(at 193.04 74.93 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7874,15 +8122,15 @@
 		(fields_autoplaced yes)
 		(uuid "8f4cd097-e5d4-4660-8de8-1c5ed8a12894")
 		(property "Reference" "R14"
-			(at 191.77 64.77 90)
+			(at 193.04 68.58 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 			)
 		)
-		(property "Value" "68k"
-			(at 191.77 67.31 90)
+		(property "Value" "33k"
+			(at 193.04 71.12 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7890,7 +8138,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 191.516 72.136 90)
+			(at 192.786 75.946 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7899,7 +8147,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 191.77 71.12 0)
+			(at 193.04 74.93 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7908,7 +8156,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 191.77 71.12 0)
+			(at 193.04 74.93 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8074,7 +8322,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 180.34 71.12 270)
+		(at 182.88 74.93 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8082,7 +8330,7 @@
 		(dnp no)
 		(uuid "9e3c6581-eabd-4cea-8f93-0b06ac753de2")
 		(property "Reference" "RV7"
-			(at 181.6101 68.58 0)
+			(at 180.34 73.6599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8090,8 +8338,8 @@
 				(justify right)
 			)
 		)
-		(property "Value" "250k"
-			(at 179.0701 68.58 0)
+		(property "Value" "100k"
+			(at 180.34 76.1999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8100,7 +8348,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 180.34 71.12 0)
+			(at 182.88 74.93 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8109,7 +8357,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 180.34 71.12 0)
+			(at 182.88 74.93 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8117,8 +8365,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "PWM Lvl"
-			(at 180.34 62.23 90)
+		(property "Description" "PWM Amt"
+			(at 185.42 80.518 90)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/DMH_VCO_40106_PCB/Core.kicad_sch
+++ b/DMH_VCO_40106_PCB/Core.kicad_sch
@@ -2884,6 +2884,12 @@
 		(uuid "31e0807b-f998-4f11-9032-ae7bd302d351")
 	)
 	(junction
+		(at 63.5 133.35)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "37bc4491-84b5-4a41-b382-e372e71c3905")
+	)
+	(junction
 		(at 153.67 24.13)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -2908,34 +2914,16 @@
 		(uuid "7bdc28c0-aa8d-4879-b9d9-fec06df6ed7e")
 	)
 	(junction
-		(at 50.8 133.35)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "8621d812-a9eb-4d0a-b702-2f04e63bd9b8")
-	)
-	(junction
 		(at 190.5 29.21)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "87560534-6723-4cfc-b5e1-e63f9ec9f5a5")
 	)
 	(junction
-		(at 50.8 152.4)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "98cb7d72-f051-4b84-8a9e-9fc1da713986")
-	)
-	(junction
 		(at 63.5 73.66)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "999cab1d-6ec4-4bf1-818d-422424e7a463")
-	)
-	(junction
-		(at 63.5 133.35)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "9c171164-72bb-4bae-bfe8-1d862715229b")
 	)
 	(junction
 		(at 82.55 107.95)
@@ -2984,16 +2972,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d422d8f8-e13e-4112-aab9-1d5701fb4960")
-	)
-	(wire
-		(pts
-			(xy 63.5 133.35) (xy 63.5 152.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "03f40c9a-ff5e-4d3a-a00e-7cfed323cce6")
 	)
 	(wire
 		(pts
@@ -3247,16 +3225,6 @@
 	)
 	(wire
 		(pts
-			(xy 48.26 133.35) (xy 50.8 133.35)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "38ae4e83-a084-4c4b-a22a-b4e257fc4935")
-	)
-	(wire
-		(pts
 			(xy 110.49 93.98) (xy 110.49 100.33)
 		)
 		(stroke
@@ -3287,16 +3255,6 @@
 	)
 	(wire
 		(pts
-			(xy 57.15 139.7) (xy 50.8 139.7)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3e426915-9750-4588-b032-c752addd39cd")
-	)
-	(wire
-		(pts
 			(xy 25.4 39.37) (xy 25.4 46.99)
 		)
 		(stroke
@@ -3304,6 +3262,16 @@
 			(type default)
 		)
 		(uuid "3e932d86-9da5-4e58-854d-58bc67321fe3")
+	)
+	(wire
+		(pts
+			(xy 60.96 152.4) (xy 63.5 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f16481d-a2ca-42ce-a0ab-5a21931c5763")
 	)
 	(wire
 		(pts
@@ -3357,16 +3325,6 @@
 	)
 	(wire
 		(pts
-			(xy 57.15 156.21) (xy 57.15 158.75)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "46bd9163-fec2-4a1a-b1e3-fee31dd14b9b")
-	)
-	(wire
-		(pts
 			(xy 118.11 102.87) (xy 118.11 100.33)
 		)
 		(stroke
@@ -3394,16 +3352,6 @@
 			(type default)
 		)
 		(uuid "4d8f79cb-3463-4f61-a092-8f2b84cffa12")
-	)
-	(wire
-		(pts
-			(xy 57.15 158.75) (xy 50.8 158.75)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "526fec58-c5fb-4faf-a326-10b7ea7c2cb1")
 	)
 	(wire
 		(pts
@@ -3477,6 +3425,16 @@
 	)
 	(wire
 		(pts
+			(xy 36.83 127) (xy 36.83 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "662caa03-27ad-4271-9a75-ad5e14f81e2b")
+	)
+	(wire
+		(pts
 			(xy 33.02 39.37) (xy 36.83 39.37)
 		)
 		(stroke
@@ -3497,16 +3455,6 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 152.4) (xy 63.5 152.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6a3bdfa8-2eec-4fc3-9134-49c3fac1fde8")
-	)
-	(wire
-		(pts
 			(xy 82.55 107.95) (xy 92.71 107.95)
 		)
 		(stroke
@@ -3517,16 +3465,6 @@
 	)
 	(wire
 		(pts
-			(xy 48.26 152.4) (xy 50.8 152.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6b188aea-aeb6-4502-9a80-d8014dcb4ee7")
-	)
-	(wire
-		(pts
 			(xy 19.05 64.77) (xy 19.05 67.31)
 		)
 		(stroke
@@ -3534,16 +3472,6 @@
 			(type default)
 		)
 		(uuid "6cd0fcf3-7f48-41e4-8b80-557b23906756")
-	)
-	(wire
-		(pts
-			(xy 57.15 137.16) (xy 57.15 139.7)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6e546e1f-5c14-412b-986b-ec05467abfef")
 	)
 	(wire
 		(pts
@@ -3584,6 +3512,16 @@
 			(type default)
 		)
 		(uuid "78a91eb9-c580-4367-aa0f-2ea19bad3a4c")
+	)
+	(wire
+		(pts
+			(xy 36.83 137.16) (xy 36.83 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "78d9bf0f-d4bc-4213-89a8-d8e168154eb0")
 	)
 	(wire
 		(pts
@@ -3657,16 +3595,6 @@
 	)
 	(wire
 		(pts
-			(xy 25.4 133.35) (xy 30.48 133.35)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "818e4a96-4368-4604-af08-d7104e7eec3b")
-	)
-	(wire
-		(pts
 			(xy 100.33 86.36) (xy 100.33 91.44)
 		)
 		(stroke
@@ -3677,13 +3605,13 @@
 	)
 	(wire
 		(pts
-			(xy 60.96 133.35) (xy 63.5 133.35)
+			(xy 63.5 133.35) (xy 63.5 152.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "8785adf7-91e9-4fee-b32f-64c0278ee8dd")
+		(uuid "8cc31db5-dd29-4540-8a24-285256f6099b")
 	)
 	(wire
 		(pts
@@ -3707,16 +3635,6 @@
 	)
 	(wire
 		(pts
-			(xy 50.8 152.4) (xy 53.34 152.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "90298d41-b23c-4c27-99d0-7ac36d9a5041")
-	)
-	(wire
-		(pts
 			(xy 210.82 64.77) (xy 213.36 64.77)
 		)
 		(stroke
@@ -3724,16 +3642,6 @@
 			(type default)
 		)
 		(uuid "92e12b5f-4fbc-428a-ac0b-ad6f3d10bad1")
-	)
-	(wire
-		(pts
-			(xy 25.4 152.4) (xy 30.48 152.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "94ebe874-1833-4307-bad8-42a74d81fb86")
 	)
 	(wire
 		(pts
@@ -3787,16 +3695,6 @@
 	)
 	(wire
 		(pts
-			(xy 50.8 139.7) (xy 50.8 133.35)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a19f9559-5d68-4134-973b-e223fb79008b")
-	)
-	(wire
-		(pts
 			(xy 143.51 53.34) (xy 143.51 57.15)
 		)
 		(stroke
@@ -3824,6 +3722,16 @@
 			(type default)
 		)
 		(uuid "a8618718-a11b-4288-91cb-b896dda71072")
+	)
+	(wire
+		(pts
+			(xy 36.83 156.21) (xy 36.83 158.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a9881da0-5a3e-4b91-9238-7847e00d19b4")
 	)
 	(wire
 		(pts
@@ -3857,6 +3765,16 @@
 	)
 	(wire
 		(pts
+			(xy 60.96 133.35) (xy 63.5 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad4a5d4a-784d-43c8-8940-34f7537c6a9a")
+	)
+	(wire
+		(pts
 			(xy 125.73 86.36) (xy 130.81 86.36)
 		)
 		(stroke
@@ -3884,6 +3802,16 @@
 			(type default)
 		)
 		(uuid "b343e5f0-275f-4cf0-a2f2-4e9f1792e2b0")
+	)
+	(wire
+		(pts
+			(xy 36.83 146.05) (xy 36.83 148.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b37ef866-eabf-43ff-93e4-ba31fc55df7f")
 	)
 	(wire
 		(pts
@@ -3987,6 +3915,16 @@
 	)
 	(wire
 		(pts
+			(xy 40.64 152.4) (xy 43.18 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9588f4c-9b9f-4212-a35e-12de587fe416")
+	)
+	(wire
+		(pts
 			(xy 190.5 29.21) (xy 181.61 29.21)
 		)
 		(stroke
@@ -4017,6 +3955,16 @@
 	)
 	(wire
 		(pts
+			(xy 40.64 133.35) (xy 43.18 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d67e5f8b-4732-444a-9086-ec0b02c5b80e")
+	)
+	(wire
+		(pts
 			(xy 213.36 64.77) (xy 226.06 64.77)
 		)
 		(stroke
@@ -4024,6 +3972,16 @@
 			(type default)
 		)
 		(uuid "da0d94aa-9800-4704-ae67-a7200d8db7ed")
+	)
+	(wire
+		(pts
+			(xy 25.4 146.05) (xy 36.83 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dcba655f-3bdc-4b3c-aa09-283ce44d2beb")
 	)
 	(wire
 		(pts
@@ -4127,23 +4085,13 @@
 	)
 	(wire
 		(pts
-			(xy 38.1 152.4) (xy 40.64 152.4)
+			(xy 50.8 152.4) (xy 53.34 152.4)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "e785af3b-3d6c-4338-ad85-69284b26f567")
-	)
-	(wire
-		(pts
-			(xy 50.8 158.75) (xy 50.8 152.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e876528f-45ec-4663-a5d5-9cc49bd77e54")
 	)
 	(wire
 		(pts
@@ -4158,16 +4106,6 @@
 	(wire
 		(pts
 			(xy 50.8 133.35) (xy 53.34 133.35)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ec371534-bb72-4f67-b56e-5aa556d7b8be")
-	)
-	(wire
-		(pts
-			(xy 38.1 133.35) (xy 40.64 133.35)
 		)
 		(stroke
 			(width 0)
@@ -4204,6 +4142,16 @@
 			(type default)
 		)
 		(uuid "fbcfcb1c-d71e-4e82-a8d0-ec8a4e2fd66b")
+	)
+	(wire
+		(pts
+			(xy 25.4 127) (xy 36.83 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fc24e5cb-301c-4942-8959-5df2e2a50ed8")
 	)
 	(wire
 		(pts
@@ -4262,30 +4210,6 @@
 		(uuid 39165d86-ba24-4f26-a39b-a36c41f539fb)
 	)
 	(circle
-		(center 57.15 152.4)
-		(radius 6.8392)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(fill
-			(type none)
-		)
-		(uuid b3c6fcd8-3a15-4ec1-af78-dcce543e595f)
-	)
-	(circle
-		(center 57.912 134.112)
-		(radius 6.8392)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(fill
-			(type none)
-		)
-		(uuid c06b1642-8502-463d-9861-ddcd239a003d)
-	)
-	(circle
 		(center 153.162 69.342)
 		(radius 6.8392)
 		(stroke
@@ -4306,16 +4230,6 @@
 			)
 		)
 		(uuid "09690317-5714-412a-a1bf-9b2a232140d1")
-	)
-	(text "used 100k for now"
-		(exclude_from_sim no)
-		(at 57.658 161.036 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-		)
-		(uuid "3f5982df-e20e-481e-b762-05db38f3a9f6")
 	)
 	(text "used 1k + 510R for now"
 		(exclude_from_sim no)
@@ -4349,23 +4263,14 @@
 	)
 	(text "RD09 pots pinout:\nwhen viewing the pot from above and the pins are on the south side,\n1 = right = fully CW\n2 = middle\n3 = left = fully CCW"
 		(exclude_from_sim no)
-		(at 62.484 19.05 0)
+		(at 26.67 19.304 0)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
+			(justify left)
 		)
 		(uuid "a21d1940-3de9-4795-a44e-603b4169a4e7")
-	)
-	(text "used 100k for now"
-		(exclude_from_sim no)
-		(at 58.42 142.24 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-		)
-		(uuid "c331c931-0da8-4e3f-b69b-e0fc46b1553e")
 	)
 	(text "used 2 68k in parallel for now"
 		(exclude_from_sim no)
@@ -4379,7 +4284,7 @@
 	)
 	(hierarchical_label "Exp FM In 1"
 		(shape input)
-		(at 25.4 133.35 180)
+		(at 25.4 127 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4415,7 +4320,7 @@
 	)
 	(hierarchical_label "Sync In"
 		(shape input)
-		(at 25.4 170.18 180)
+		(at 25.4 190.5 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4451,7 +4356,7 @@
 	)
 	(hierarchical_label "Exp FM In 2"
 		(shape input)
-		(at 25.4 152.4 180)
+		(at 25.4 146.05 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -4866,7 +4771,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 34.29 133.35 90)
+		(at 46.99 133.35 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -4875,7 +4780,7 @@
 		(fields_autoplaced yes)
 		(uuid "15985414-f8f9-4693-b750-b9d3781c8893")
 		(property "Reference" "R8"
-			(at 34.29 127 90)
+			(at 46.99 127 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4883,7 +4788,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 34.29 129.54 90)
+			(at 46.99 129.54 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4891,7 +4796,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 34.544 132.334 90)
+			(at 47.244 132.334 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4900,7 +4805,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 34.29 133.35 0)
+			(at 46.99 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4909,7 +4814,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 34.29 133.35 0)
+			(at 46.99 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6148,7 +6053,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 44.45 133.35 90)
+		(at 57.15 133.35 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6157,7 +6062,7 @@
 		(fields_autoplaced yes)
 		(uuid "6b0b508a-e7f1-4ff1-8d49-157744931258")
 		(property "Reference" "TH5"
-			(at 44.45 127 90)
+			(at 57.15 127 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6165,7 +6070,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 44.45 129.54 90)
+			(at 57.15 129.54 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6173,7 +6078,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 44.45 133.35 0)
+			(at 57.15 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6182,7 +6087,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 44.45 133.35 0)
+			(at 57.15 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6191,7 +6096,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 44.45 133.35 0)
+			(at 57.15 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6216,7 +6121,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 57.15 133.35 270)
+		(at 36.83 133.35 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6224,7 +6129,7 @@
 		(dnp no)
 		(uuid "6b9172ff-a1bd-449b-89ff-439171a9e7c7")
 		(property "Reference" "RV3"
-			(at 58.4201 130.81 0)
+			(at 34.29 132.0799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6232,8 +6137,8 @@
 				(justify right)
 			)
 		)
-		(property "Value" "1M"
-			(at 55.8801 130.81 0)
+		(property "Value" "100k"
+			(at 34.29 134.6199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6242,7 +6147,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 57.15 133.35 0)
+			(at 36.83 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6251,7 +6156,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 57.15 133.35 0)
+			(at 36.83 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6259,8 +6164,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Exp FM Lvl"
-			(at 56.896 125.984 90)
+		(property "Description" "Exp FM 1 Amt"
+			(at 21.844 133.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6430,7 +6335,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 34.29 152.4 90)
+		(at 46.99 152.4 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6439,7 +6344,7 @@
 		(fields_autoplaced yes)
 		(uuid "701d67d6-1d5b-4af8-b8dc-39401241cc3a")
 		(property "Reference" "R9"
-			(at 34.29 146.05 90)
+			(at 46.99 146.05 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6447,7 +6352,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 34.29 148.59 90)
+			(at 46.99 148.59 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6455,7 +6360,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 34.544 151.384 90)
+			(at 47.244 151.384 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6464,7 +6369,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 34.29 152.4 0)
+			(at 46.99 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6473,7 +6378,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 34.29 152.4 0)
+			(at 46.99 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6973,6 +6878,71 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 36.83 158.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "864e9607-153b-4542-b309-7b9596c0220b")
+		(property "Reference" "#PWR040"
+			(at 36.83 165.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 36.83 162.814 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 36.83 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 36.83 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 36.83 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0c10fa5d-1664-4ef7-99aa-6c4f663176e8")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "#PWR040")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R_US")
 		(at 181.61 40.64 180)
 		(unit 1)
@@ -7324,7 +7294,7 @@
 	)
 	(symbol
 		(lib_id "Device:Thermistor_US")
-		(at 44.45 152.4 90)
+		(at 57.15 152.4 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7333,7 +7303,7 @@
 		(fields_autoplaced yes)
 		(uuid "a0ba07f5-4440-4c30-95d5-cddf684f9052")
 		(property "Reference" "TH6"
-			(at 44.45 146.05 90)
+			(at 57.15 146.05 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7341,7 +7311,7 @@
 			)
 		)
 		(property "Value" "10k"
-			(at 44.45 148.59 90)
+			(at 57.15 148.59 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7349,7 +7319,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_THT:R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal"
-			(at 44.45 152.4 0)
+			(at 57.15 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7358,7 +7328,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 44.45 152.4 0)
+			(at 57.15 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7367,7 +7337,7 @@
 			)
 		)
 		(property "Description" "Thermistor, temperature dependent resistor, US symbol"
-			(at 44.45 152.4 0)
+			(at 57.15 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7867,7 +7837,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_Potentiometer_US")
-		(at 57.15 152.4 270)
+		(at 36.83 152.4 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7875,7 +7845,7 @@
 		(dnp no)
 		(uuid "c73e43ee-1467-4bd1-8894-cec8720a207b")
 		(property "Reference" "RV4"
-			(at 58.4201 149.86 0)
+			(at 34.29 151.1299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7883,8 +7853,8 @@
 				(justify right)
 			)
 		)
-		(property "Value" "1M"
-			(at 55.8801 149.86 0)
+		(property "Value" "100k"
+			(at 34.29 153.6699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7893,7 +7863,7 @@
 			)
 		)
 		(property "Footprint" "Potentiometer_THT:Potentiometer_Alpha_RD901F-40-00D_Single_Vertical"
-			(at 57.15 152.4 0)
+			(at 36.83 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7902,7 +7872,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 57.15 152.4 0)
+			(at 36.83 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7910,8 +7880,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Lin FM Lvl"
-			(at 56.896 145.034 90)
+		(property "Description" "Exp FM 2 Amt"
+			(at 21.59 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8483,6 +8453,71 @@
 			(project ""
 				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
 					(reference "#PWR019")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 36.83 139.7 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dc4c1fbf-8f63-48ab-a5e8-5cb004c8a344")
+		(property "Reference" "#PWR033"
+			(at 36.83 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 36.83 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 36.83 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 36.83 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 36.83 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f8b1bdef-6292-4099-95ea-6ca9c85861ae")
+		)
+		(instances
+			(project "DMH_VCO_40106_PCB"
+				(path "/fefed352-c100-4617-bbfb-c55e7427b122/681eb850-910f-47de-ab28-b72b47bdbc38"
+					(reference "#PWR033")
 					(unit 1)
 				)
 			)


### PR DESCRIPTION
Redesigned circuitry to provide better control of
- Fine tuning: now with centering and range adjustments
- Exponential FM inputs: now can be fully atenuated with pot fully CCW
- PW: now with symmetry and range adjustments, and modulation can be fully atenuated with pot fully CCW

Improved core circuitry to allow for better V/oct calibration on the low pitch regions by:
- Adding inveting -1 gain opamp stage and second inverting opamp stage to scale down CV inputs
- Increasing the exponentiator capacitor to 10nF